### PR TITLE
Improve query modal

### DIFF
--- a/client/src/QueryChartOnly.tsx
+++ b/client/src/QueryChartOnly.tsx
@@ -15,6 +15,7 @@ import {
   useStatementColumns,
   useStatementIncomplete,
   useStatementRowCount,
+  useStatementStatus,
 } from './stores/editor-store';
 import { api } from './utilities/api';
 
@@ -32,7 +33,8 @@ function QueryChartOnly({ queryId }: Props) {
   const chartFields = useSessionChartFields();
   const chartType = useSessionChartType();
   const columns = useStatementColumns(statementId);
-  const { data: rows } = api.useStatementResults(statementId);
+  const status = useStatementStatus(statementId);
+  const { data: rows } = api.useStatementResults(statementId, status);
 
   useEffect(() => {
     loadQuery(queryId).then(() => runQuery());

--- a/client/src/common/Input.tsx
+++ b/client/src/common/Input.tsx
@@ -10,7 +10,10 @@ export interface Props extends React.HTMLProps<HTMLInputElement> {
   required?: boolean;
 }
 
-export default function Input({ children, error, className, ...rest }: Props) {
+export type Ref = HTMLInputElement | null;
+
+const Input = React.forwardRef<Ref, Props>((props, ref) => {
+  const { children, error, className, ...rest } = props;
   const classNames = [styles.input];
 
   if (error) {
@@ -22,8 +25,10 @@ export default function Input({ children, error, className, ...rest }: Props) {
   }
 
   return (
-    <input className={classNames.join(' ')} {...rest}>
+    <input ref={ref} className={classNames.join(' ')} {...rest}>
       {children}
     </input>
   );
-}
+});
+
+export default Input;

--- a/client/src/common/Modal.tsx
+++ b/client/src/common/Modal.tsx
@@ -9,9 +9,17 @@ export interface Props extends React.HTMLAttributes<HTMLElement> {
   visible?: boolean;
   onClose?: () => void;
   width: string | number;
+  initialFocusRef?: React.RefObject<any>;
 }
 
-function Modal({ title, visible, onClose, width, children }: Props) {
+function Modal({
+  title,
+  visible,
+  onClose,
+  width,
+  initialFocusRef,
+  children,
+}: Props) {
   if (visible) {
     return (
       <Dialog
@@ -21,6 +29,7 @@ function Modal({ title, visible, onClose, width, children }: Props) {
         style={{
           width,
         }}
+        initialFocusRef={initialFocusRef}
       >
         <div className={styles.titleWrapper}>
           <span>{title}</span>

--- a/client/src/common/QueryResultContainer.tsx
+++ b/client/src/common/QueryResultContainer.tsx
@@ -18,11 +18,11 @@ export interface Props {
 
 function QueryResultContainer({ statementId }: Props) {
   const columns = useStatementColumns(statementId) || [];
-  const { data, error } = api.useStatementResults(statementId);
   const rowCount = useStatementRowCount(statementId);
   const status = useStatementStatus(statementId);
   const isRunning = useSessionIsRunning();
   const queryError = useSessionQueryError();
+  const { data, error } = api.useStatementResults(statementId, status);
 
   if (isRunning || (status === 'finished' && !data)) {
     return <QueryResultRunning />;

--- a/client/src/css/index.css
+++ b/client/src/css/index.css
@@ -149,7 +149,7 @@ input {
   overflow: auto;
 
   font-size: 1.3rem;
-  padding: 24px;
+  padding: 16px;
   text-align: center;
   color: hsl(323, 100%, 42%);
 }

--- a/client/src/queryEditor/QueryEditorChart.tsx
+++ b/client/src/queryEditor/QueryEditorChart.tsx
@@ -7,6 +7,7 @@ import {
   useSessionIsRunning,
   useSessionQueryId,
   useStatementColumns,
+  useStatementStatus,
 } from '../stores/editor-store';
 import { api } from '../utilities/api';
 
@@ -17,7 +18,8 @@ const ConnectedChart: FunctionComponent = (props) => {
   const chartFields = useSessionChartFields();
   const statementId = useLastStatementId();
   const columns = useStatementColumns(statementId);
-  const { data } = api.useStatementResults(statementId);
+  const status = useStatementStatus(statementId);
+  const { data } = api.useStatementResults(statementId, status);
 
   const chartConfiguration = useMemo(() => {
     return {

--- a/client/src/queryEditor/QuerySaveModal.tsx
+++ b/client/src/queryEditor/QuerySaveModal.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent } from 'react';
+import React, { ChangeEvent, useRef } from 'react';
 import Button from '../common/Button';
 import Input from '../common/Input';
 import Modal from '../common/Modal';
@@ -33,6 +33,7 @@ function QuerySaveModal() {
   const queryName = useSessionQueryName();
   const showValidation = useSessionShowValidation();
   const isSaving = useSessionIsSaving();
+  const initialRef = useRef(null);
 
   const error = showValidation && !queryName.length;
 
@@ -57,8 +58,6 @@ function QuerySaveModal() {
 
   function handleSharedChange(event: ChangeEvent<HTMLInputElement>) {
     const { value } = event.target;
-    console.log(event.target.value);
-    console.log(event.target.checked);
     if (value === 'shared') {
       setAcl([{ groupId: '__EVERYONE__', write: true }]);
     } else if (value === 'private') {
@@ -72,10 +71,12 @@ function QuerySaveModal() {
       width={'500px'}
       visible={showSave}
       onClose={toggleShowSave}
+      initialFocusRef={initialRef}
     >
       <label>
         Query name
         <Input
+          ref={initialRef}
           error={error}
           placeholder=""
           value={queryName}

--- a/client/src/queryEditor/QuerySaveModal.tsx
+++ b/client/src/queryEditor/QuerySaveModal.tsx
@@ -20,7 +20,6 @@ import {
 import { api } from '../utilities/api';
 
 // TODO: Add option between updating existing query, or saving new query (maybe)
-// TODO: If save error occurs, display it in modal
 // TODO: Enhance share options
 
 // Instead of modelling the data as it is in the editor session

--- a/client/src/queryEditor/QuerySaveModal.tsx
+++ b/client/src/queryEditor/QuerySaveModal.tsx
@@ -1,16 +1,10 @@
-import React, { ChangeEvent, useRef } from 'react';
+import React, { ChangeEvent, useRef, useState, useEffect } from 'react';
 import Button from '../common/Button';
 import Input from '../common/Input';
 import Modal from '../common/Modal';
 import MultiSelect, { MultiSelectItem } from '../common/MultiSelect';
 import Spacer from '../common/Spacer';
-import {
-  saveQuery,
-  setAcl,
-  setQueryName,
-  setTags,
-  toggleShowSave,
-} from '../stores/editor-actions';
+import { saveQuery, toggleShowSave } from '../stores/editor-actions';
 import {
   useSessionIsSaving,
   useSessionQueryName,
@@ -18,31 +12,73 @@ import {
   useSessionShowValidation,
   useSessionTags,
   useShowSave,
+  EditorSession,
 } from '../stores/editor-store';
 import { api } from '../utilities/api';
+import HSpacer from '../common/HSpacer';
 
 // TODO: Add option between updating existing query, or saving new query (maybe)
 // TODO: If save error occurs, display it in modal
 // TODO: Enhance share options
-// TODO: Make modal state temporary until saved. Edits should be able to be cancelled.
+
+// Instead of modelling the data as it is in the editor session
+// a separate view model is used to track state
+// Session data converts to it, and on save it gets transformed back to expected format
+interface ViewModel {
+  name: string;
+  shared: 'shared' | 'private';
+  tags: string[];
+}
 
 function QuerySaveModal() {
   const showSave = useShowSave();
-  const shared = useSessionQueryShared();
-  const tags = useSessionTags();
-  const queryName = useSessionQueryName();
+  const originalShared = useSessionQueryShared();
+  const originalTags = useSessionTags();
+  const originalName = useSessionQueryName();
   const showValidation = useSessionShowValidation();
   const isSaving = useSessionIsSaving();
   const initialRef = useRef(null);
 
-  const error = showValidation && !queryName.length;
+  const [viewModel, setViewModel] = useState<ViewModel>({
+    name: originalName,
+    shared: originalShared ? 'shared' : 'private',
+    tags: originalTags || [],
+  });
+
+  function resetViewModel() {
+    setViewModel({
+      name: originalName,
+      shared: originalShared ? 'shared' : 'private',
+      tags: originalTags || [],
+    });
+  }
+
+  useEffect(() => {
+    setViewModel((vm) => ({ ...vm, name: originalName }));
+  }, [originalName]);
+
+  useEffect(() => {
+    setViewModel((vm) => ({
+      ...vm,
+      shared: originalShared ? 'shared' : 'private',
+    }));
+  }, [originalShared]);
+
+  useEffect(() => {
+    setViewModel((vm) => ({
+      ...vm,
+      tags: originalTags || [],
+    }));
+  }, [originalTags]);
+
+  const error = showValidation && !viewModel.name.length;
 
   const { data: tagsData } = api.useTags(showSave);
   const options = (tagsData || []).map((tag) => ({
     name: tag,
     id: tag,
   }));
-  const selectedItems = tags.map((tag) => ({
+  const selectedItems = viewModel.tags.map((tag) => ({
     name: tag,
     id: tag,
   }));
@@ -52,17 +88,33 @@ function QuerySaveModal() {
       .map((item) => item.name || '')
       .map((tag) => tag.trim())
       .filter((tag) => tag !== '');
-
-    setTags(tags);
+    setViewModel((vm) => ({ ...vm, tags }));
   };
 
   function handleSharedChange(event: ChangeEvent<HTMLInputElement>) {
     const { value } = event.target;
-    if (value === 'shared') {
-      setAcl([{ groupId: '__EVERYONE__', write: true }]);
-    } else if (value === 'private') {
-      setAcl([]);
+    if (value === 'shared' || value === 'private') {
+      return setViewModel((vm) => ({ ...vm, shared: value }));
     }
+    throw new Error('Unknown value ' + value);
+  }
+
+  function handleSaveRequest() {
+    const updates: Partial<EditorSession> = {
+      tags: viewModel.tags,
+      queryName: viewModel.name,
+      acl: [],
+    };
+    if (viewModel.shared === 'shared') {
+      updates.acl = [{ groupId: '__EVERYONE__', write: true }];
+    }
+
+    saveQuery(updates);
+  }
+
+  function handleCancel() {
+    toggleShowSave();
+    resetViewModel();
   }
 
   return (
@@ -70,80 +122,97 @@ function QuerySaveModal() {
       title="Save query"
       width={'500px'}
       visible={showSave}
-      onClose={toggleShowSave}
+      onClose={handleCancel}
       initialFocusRef={initialRef}
     >
-      <label>
-        Query name
-        <Input
-          ref={initialRef}
-          error={error}
-          placeholder=""
-          value={queryName}
-          onChange={(e: any) => setQueryName(e.target.value)}
-        />
-      </label>
+      <form onSubmit={handleSaveRequest}>
+        <label>
+          Query name
+          <Input
+            ref={initialRef}
+            error={error}
+            placeholder=""
+            value={viewModel.name}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => {
+              const name = e.target.value;
+              setViewModel((vm) => ({ ...vm, name }));
+            }}
+          />
+        </label>
 
-      <Spacer />
-      <Spacer />
+        <Spacer />
+        <Spacer />
 
-      <label>
-        Tags
-        <MultiSelect
-          selectedItems={selectedItems}
-          options={options}
-          onChange={handleTagsChange}
-        />
-      </label>
+        <label>
+          Tags
+          <MultiSelect
+            selectedItems={selectedItems}
+            options={options}
+            onChange={handleTagsChange}
+          />
+        </label>
 
-      <Spacer />
-      <Spacer />
+        <Spacer />
+        <Spacer />
 
-      <label>Sharing</label>
-      <Spacer />
+        <label>Sharing</label>
+        <Spacer />
 
-      <label htmlFor="private" style={{ display: 'block', width: '100%' }}>
-        <input
-          style={{ marginRight: 8 }}
-          id="private"
-          type="radio"
-          checked={!shared}
-          value="private"
-          onChange={handleSharedChange}
-        />
-        Private
-      </label>
-      <Spacer />
+        <label htmlFor="private" style={{ display: 'block', width: '100%' }}>
+          <input
+            style={{ marginRight: 8 }}
+            id="private"
+            type="radio"
+            checked={viewModel.shared === 'private'}
+            value="private"
+            onChange={handleSharedChange}
+          />
+          Private
+        </label>
+        <Spacer />
 
-      <label htmlFor="shared" style={{ display: 'block', width: '100%' }}>
-        <input
-          style={{ marginRight: 8 }}
-          id="shared"
-          type="radio"
-          value="shared"
-          checked={shared}
-          onChange={handleSharedChange}
-        />
-        Shared
-      </label>
+        <label htmlFor="shared" style={{ display: 'block', width: '100%' }}>
+          <input
+            style={{ marginRight: 8 }}
+            id="shared"
+            type="radio"
+            value="shared"
+            checked={viewModel.shared === 'shared'}
+            onChange={handleSharedChange}
+          />
+          Shared
+        </label>
 
-      {/* 
+        {/* 
         TODO expand on sharing options. 
         Can be shared with specific users.
         Everyone can be read or write.
       */}
 
-      <Spacer />
-      <Spacer />
+        <Spacer />
 
-      <Button
-        className="w-100"
-        variant="primary"
-        disabled={isSaving || Boolean(error)}
-        onClick={() => saveQuery()}
-      >
-        Save
-      </Button>
+        <div
+          style={{
+            display: 'flex',
+            borderTop: '1px solid #ddd',
+            marginTop: 16,
+          }}
+        >
+          <Button
+            type="submit"
+            style={{ width: '50%' }}
+            variant="primary"
+            disabled={isSaving || Boolean(error)}
+            onClick={() => handleSaveRequest()}
+          >
+            Save
+          </Button>
+          <HSpacer />
+          <Button style={{ width: '50%' }} onClick={handleCancel}>
+            Cancel
+          </Button>
+        </div>
+      </form>
     </Modal>
   );
 }

--- a/client/src/queryEditor/QuerySaveModal.tsx
+++ b/client/src/queryEditor/QuerySaveModal.tsx
@@ -1,21 +1,23 @@
-import React, { ChangeEvent, useRef, useState, useEffect } from 'react';
+import React, { ChangeEvent, useEffect, useRef, useState } from 'react';
 import Button from '../common/Button';
+import ErrorBlock from '../common/ErrorBlock';
+import HSpacer from '../common/HSpacer';
 import Input from '../common/Input';
 import Modal from '../common/Modal';
 import MultiSelect, { MultiSelectItem } from '../common/MultiSelect';
 import Spacer from '../common/Spacer';
 import { saveQuery, toggleShowSave } from '../stores/editor-actions';
 import {
+  EditorSession,
   useSessionIsSaving,
   useSessionQueryName,
   useSessionQueryShared,
+  useSessionSaveError,
   useSessionShowValidation,
   useSessionTags,
   useShowSave,
-  EditorSession,
 } from '../stores/editor-store';
 import { api } from '../utilities/api';
-import HSpacer from '../common/HSpacer';
 
 // TODO: Add option between updating existing query, or saving new query (maybe)
 // TODO: If save error occurs, display it in modal
@@ -37,6 +39,7 @@ function QuerySaveModal() {
   const originalName = useSessionQueryName();
   const showValidation = useSessionShowValidation();
   const isSaving = useSessionIsSaving();
+  const saveError = useSessionSaveError();
   const initialRef = useRef(null);
 
   const [viewModel, setViewModel] = useState<ViewModel>({
@@ -184,12 +187,14 @@ function QuerySaveModal() {
         </label>
 
         {/* 
-        TODO expand on sharing options. 
-        Can be shared with specific users.
-        Everyone can be read or write.
-      */}
+          TODO expand on sharing options. 
+          Can be shared with specific users.
+          Everyone can be read or write.
+        */}
 
         <Spacer />
+
+        {saveError && <ErrorBlock>{saveError}</ErrorBlock>}
 
         <div
           style={{

--- a/client/src/stores/editor-actions.ts
+++ b/client/src/stores/editor-actions.ts
@@ -437,7 +437,7 @@ export const saveQuery = async (additionalUpdates?: Partial<EditorSession>) => {
     return;
   }
 
-  setSession({ isSaving: true });
+  setSession({ isSaving: true, saveError: undefined });
   const queryData = {
     connectionId,
     name: queryName,
@@ -454,8 +454,11 @@ export const saveQuery = async (additionalUpdates?: Partial<EditorSession>) => {
     api.put(`/api/queries/${queryId}`, queryData).then((json) => {
       const { error, data } = json;
       if (error) {
-        message.error(error);
-        setSession({ isSaving: false });
+        // If there was an error, show the save dialog.
+        // It might be closed and it is where the error is placed.
+        // This should be rare, and not sure what might trigger it at this point, but just in case
+        setSession({ isSaving: false, saveError: error });
+        setState({ showSave: true });
         return;
       }
       api.reloadQueries();
@@ -480,8 +483,11 @@ export const saveQuery = async (additionalUpdates?: Partial<EditorSession>) => {
     api.post(`/api/queries`, queryData).then((json) => {
       const { error, data } = json;
       if (error) {
-        message.error(error);
-        setSession({ isSaving: false });
+        // If there was an error, show the save dialog.
+        // It might be closed and it is where the error is placed.
+        // This should be rare, and not sure what might trigger it at this point, but just in case
+        setSession({ isSaving: false, saveError: error });
+        setState({ showSave: true });
         return;
       }
       api.reloadQueries();

--- a/client/src/stores/editor-actions.ts
+++ b/client/src/stores/editor-actions.ts
@@ -417,7 +417,9 @@ export const runQuery = async () => {
   });
 };
 
-export const saveQuery = async () => {
+export const saveQuery = async (additionalUpdates?: Partial<EditorSession>) => {
+  const mergedSession = { ...getState().getSession(), ...additionalUpdates };
+
   const {
     queryId,
     connectionId,
@@ -427,7 +429,7 @@ export const saveQuery = async () => {
     chartType,
     tags,
     acl,
-  } = getState().getSession();
+  } = mergedSession;
 
   if (!queryName) {
     setSession({ showValidation: true });

--- a/client/src/stores/editor-store.ts
+++ b/client/src/stores/editor-store.ts
@@ -27,6 +27,7 @@ export interface EditorSession {
   batchId?: string;
   isRunning: boolean;
   isSaving: boolean;
+  saveError?: string;
   // Editor session takes Query model fields and flattens
   queryId?: string;
   queryName: string;
@@ -71,6 +72,7 @@ export const INITIAL_SESSION: EditorSession = {
   batchId: undefined,
   isRunning: false,
   isSaving: false,
+  saveError: undefined,
   queryId: undefined,
   queryName: '',
   queryText: '',
@@ -122,6 +124,10 @@ export function useSessionQueryShared() {
     const { acl } = s.getSession();
     return (acl || []).length > 0;
   });
+}
+
+export function useSessionSaveError() {
+  return useEditorStore((s) => s.getSession().saveError);
 }
 
 export function useSessionTags() {

--- a/client/src/utilities/api.ts
+++ b/client/src/utilities/api.ts
@@ -130,9 +130,17 @@ export const api = {
     return this.get<StatementResults>(`/api/statements/${statementId}/results`);
   },
 
-  useStatementResults(statementId?: string) {
+  /**
+   * Get statement results, but only if statement is finished
+   * This is important because these gets are deduped/cached
+   * @param statementId
+   * @param status
+   */
+  useStatementResults(statementId?: string, status?: string) {
     return useSWR<StatementResults>(
-      statementId ? `/api/statements/${statementId}/results` : null
+      statementId && status === 'finished'
+        ? `/api/statements/${statementId}/results`
+        : null
     );
   },
 


### PR DESCRIPTION
Follow up to #871 with the following

* Uses temporary state for query modal form allowing cancellation
* Adds error message to modal
* Opens modal if save via shortcut and error occurs

Bonus:
* Also fixes caching of empty query results before query finish