### PR TITLE
Remove open admin registration

### DIFF
--- a/client/src/SignUp.tsx
+++ b/client/src/SignUp.tsx
@@ -5,10 +5,8 @@ import Input from './common/Input';
 import message from './common/message';
 import Spacer from './common/Spacer';
 import { api } from './utilities/api';
-import useAppContext from './utilities/use-app-context';
 
 function SignUp() {
-  const { adminRegistrationOpen } = useAppContext();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [passwordConfirmation, setPasswordConfirmation] = useState('');
@@ -36,17 +34,6 @@ function SignUp() {
     <div style={{ width: '300px', textAlign: 'center', margin: '100px auto' }}>
       <form onSubmit={signUp}>
         <h1>SQLPad</h1>
-        {adminRegistrationOpen && (
-          <div>
-            <h2>Admin registration open</h2>
-            <p>
-              Welcome to SQLPad! Since there are no admins currently registered,
-              signup is open to anyone. By signing up, you will be granted admin
-              rights, and signup will be restricted to added email addresses and
-              allowed domains
-            </p>
-          </div>
-        )}
         <Input
           name="email"
           type="email"

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -89,7 +89,6 @@ export interface ConnectionClient {
 }
 
 export interface AppInfo {
-  adminRegistrationOpen: boolean;
   config: {
     allowCsvDownload: boolean;
     // baseUrl app is mounted in. ie "/sqlpad"

--- a/client/src/utilities/use-app-context.ts
+++ b/client/src/utilities/use-app-context.ts
@@ -4,7 +4,7 @@ import { api } from './api';
 function useAppContext() {
   let { data } = api.useAppInfo();
 
-  const { config, currentUser, adminRegistrationOpen, version } = data || {};
+  const { config, currentUser, version } = data || {};
 
   if (!config) {
     return {};
@@ -12,7 +12,7 @@ function useAppContext() {
 
   baseUrl(config.baseUrl);
 
-  return { config, currentUser, adminRegistrationOpen, version };
+  return { config, currentUser, version };
 }
 
 export default useAppContext;

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -4,11 +4,13 @@
 
 By default, SQLPad supports local authentication with email and password. Passwords are stored in SQLPad's embedded database using bcrypt hashing.
 
-Once SQLPad is running, you may create an initial admin account by navigating to [http://localhost/signup](http://localhost/signup).
+To create an initial user, set `SQLPAD_ADMIN` to the email address of the initial admin user. Once SQLPad is running, you may create an initial admin account by navigating to [http://localhost/signup](http://localhost/signup).
 
-Once an initial admin account has been created, all future users must be added by an admin within the users page. Other users may also be given admin rights, allowing them to add/edit database connections and add/modify/remove SQLPad users.
+Instead of using the sign up form, a password may be set by setting `SQLPAD_ADMIN_PASSWORD` environment variable.
 
-If for whatever reason you lose admin rights, and the last-admin-standing won't give you admin rights back, you can reinstate them to yourself by setting environment variable `SQLPAD_ADMIN=yourEmailAddress@domain.com`.
+These environment variables may also be used in the future to reinstate admin access or set the admin password if the password is lost.
+
+All other local auth users must be added by an admin within the users page. Other users may also be given admin rights, allowing them to add/edit database connections and add/modify/remove SQLPad users.
 
 Local authentication can be disabled by setting `SQLPAD_USERPASS_AUTH_DISABLED=true`.
 
@@ -132,8 +134,6 @@ SQLPad users do not need to be added ahead of time, and may be created on the fl
 ## LDAP (Experimental)
 
 ?> Available as of 5.8.0
-
-!> LDAP does not honor "open admin registration" for initial log in. Use `SQLPAD_ADMIN` to set initial admin email address if necessary
 
 LDAP-based authentication can be enabled by setting the necessary environment variables:
 

--- a/server/auth-strategies/google.js
+++ b/server/auth-strategies/google.js
@@ -20,10 +20,7 @@ async function passportGoogleStrategyHandler(
   }
 
   try {
-    let [openAdminRegistration, user] = await Promise.all([
-      models.users.adminRegistrationOpen(),
-      models.users.findOneByEmail(email),
-    ]);
+    let user = await models.users.findOneByEmail(email);
 
     if (user) {
       if (user.disabled) {
@@ -36,10 +33,10 @@ async function passportGoogleStrategyHandler(
       return done(null, newUser);
     }
     const allowedDomains = config.get('allowedDomains');
-    if (openAdminRegistration || checkAllowedDomains(allowedDomains, email)) {
+    if (checkAllowedDomains(allowedDomains, email)) {
       const newUser = await models.users.create({
         email,
-        role: openAdminRegistration ? 'admin' : 'editor',
+        role: 'editor',
         signupAt: new Date(),
       });
       webhooks.userCreated(newUser);

--- a/server/auth-strategies/oidc.js
+++ b/server/auth-strategies/oidc.js
@@ -29,10 +29,7 @@ async function passportOidcStrategyHandler(
   }
 
   try {
-    let [openAdminRegistration, user] = await Promise.all([
-      models.users.adminRegistrationOpen(),
-      models.users.findOneByEmail(email),
-    ]);
+    let user = await models.users.findOneByEmail(email);
 
     if (user) {
       if (user.disabled) {
@@ -48,11 +45,11 @@ async function passportOidcStrategyHandler(
       return done(null, newUser);
     }
     const allowedDomains = config.get('allowedDomains');
-    if (openAdminRegistration || checkAllowedDomains(allowedDomains, email)) {
+    if (checkAllowedDomains(allowedDomains, email)) {
       const newUser = await models.users.create({
         name,
         email,
-        role: openAdminRegistration ? 'admin' : 'editor',
+        role: 'editor',
         signupAt: new Date(),
       });
       webhooks.userCreated(newUser);

--- a/server/auth-strategies/saml.js
+++ b/server/auth-strategies/saml.js
@@ -36,10 +36,7 @@ function enableSaml(config) {
 
           const { models, webhooks } = req;
 
-          let [openAdminRegistration, user] = await Promise.all([
-            models.users.adminRegistrationOpen(),
-            models.users.findOneByEmail(email),
-          ]);
+          let user = await models.users.findOneByEmail(email);
 
           if (user) {
             if (user.disabled) {
@@ -53,13 +50,10 @@ function enableSaml(config) {
           }
 
           // If auto sign up is turned on create user
-          if (openAdminRegistration || config.get('samlAutoSignUp')) {
+          if (config.get('samlAutoSignUp')) {
             const newUser = await models.users.create({
               email,
-              role: openAdminRegistration
-                ? 'admin'
-                : config.get('samlDefaultRole') ||
-                  config.get('samlDefaultRole_d'),
+              role: config.get('samlDefaultRole'),
               signupAt: new Date(),
             });
             webhooks.userCreated(newUser);

--- a/server/models/users.js
+++ b/server/models/users.js
@@ -81,18 +81,6 @@ class Users {
     });
   }
 
-  /**
-   * Returns boolean regarding whether admin registration should be open or not
-   * @returns {Promise<boolean>} administrationOpen
-   */
-  async adminRegistrationOpen() {
-    const doc = await this.sequelizeDb.Users.findOne({
-      attributes: ['id'],
-      where: { role: 'admin' },
-    });
-    return !doc;
-  }
-
   removeById(id) {
     return this.sequelizeDb.Users.destroy({ where: { id } });
   }

--- a/server/routes/app.js
+++ b/server/routes/app.js
@@ -8,8 +8,7 @@ const wrap = require('../lib/wrap');
  * @param {Res} res
  */
 async function getApp(req, res) {
-  const { config, models } = req;
-  const adminRegistrationOpen = await models.users.adminRegistrationOpen();
+  const { config } = req;
   const currentUser =
     req.isAuthenticated() && req.user
       ? {
@@ -21,7 +20,6 @@ async function getApp(req, res) {
       : undefined;
 
   return res.utils.data({
-    adminRegistrationOpen,
     currentUser,
     config: {
       allowCsvDownload: config.get('allowCsvDownload'),

--- a/server/routes/signup.js
+++ b/server/routes/signup.js
@@ -22,10 +22,7 @@ async function handleSignup(req, res, next) {
     return res.utils.error('Passwords do not match');
   }
 
-  let [user, adminRegistrationOpen] = await Promise.all([
-    models.users.findOneByEmail(req.body.email),
-    models.users.adminRegistrationOpen(),
-  ]);
+  let user = await models.users.findOneByEmail(req.body.email);
 
   if (user && user.passhash) {
     return res.utils.error('User already signed up');
@@ -39,16 +36,12 @@ async function handleSignup(req, res, next) {
     return next();
   }
 
-  // if open admin registration or allowed email create user
-  // otherwise exit
-  if (
-    adminRegistrationOpen ||
-    checkAllowedDomains(allowedDomains, req.body.email)
-  ) {
+  // if allowed email create user otherwise exit
+  if (checkAllowedDomains(allowedDomains, req.body.email)) {
     user = await models.users.create({
       email: req.body.email,
       password: req.body.password,
-      role: adminRegistrationOpen ? 'admin' : 'editor',
+      role: 'editor',
       signupAt: new Date(),
     });
     webhooks.userCreated(user);

--- a/server/test/api/app.js
+++ b/server/test/api/app.js
@@ -7,12 +7,7 @@ function expectKeys(data, expectedKeys) {
   );
 }
 
-const expectedKeys = [
-  'adminRegistrationOpen',
-  'currentUser',
-  'config',
-  'version',
-];
+const expectedKeys = ['currentUser', 'config', 'version'];
 
 const expectedConfigKeys = [
   'baseUrl',

--- a/server/test/api/signin.js
+++ b/server/test/api/signin.js
@@ -7,18 +7,11 @@ describe('api/signin', function () {
     it('allows new user sign in', async function () {
       const utils = new TestUtil({
         authProxyEnabled: false,
+        admin: 'admin@test.com',
+        adminPassword: 'admin',
       });
 
       await utils.init();
-
-      await request(utils.app)
-        .post('/api/signup')
-        .send({
-          password: 'admin',
-          passwordConfirmation: 'admin',
-          email: 'admin@test.com',
-        })
-        .expect(200);
 
       const agent = request.agent(utils.app);
       await agent
@@ -37,18 +30,11 @@ describe('api/signin', function () {
     it('unauthorized for bad signin', async function () {
       const utils = new TestUtil({
         authProxyEnabled: false,
+        admin: 'admin@test.com',
+        adminPassword: 'admin',
       });
 
       await utils.init();
-
-      await request(utils.app)
-        .post('/api/signup')
-        .send({
-          email: 'admin@test.com',
-          password: 'admin',
-          passwordConfirmation: 'admin',
-        })
-        .expect(200);
 
       await request(utils.app)
         .post('/api/signin')
@@ -62,19 +48,11 @@ describe('api/signin', function () {
     it('supports case insensitive login', async function () {
       const utils = new TestUtil({
         authProxyEnabled: false,
+        admin: 'admin@test.com',
+        adminPassword: 'admin',
       });
 
       await utils.init();
-
-      // Add admin user via signup
-      await request(utils.app)
-        .post('/api/signup')
-        .send({
-          password: 'admin',
-          passwordConfirmation: 'admin',
-          email: 'admin@test.com',
-        })
-        .expect(200);
 
       // Add user via API using admin
       await request(utils.app)
@@ -99,19 +77,11 @@ describe('api/signin', function () {
     it('allows emails containing +', async function () {
       const utils = new TestUtil({
         authProxyEnabled: false,
+        admin: 'admin@test.com',
+        adminPassword: 'admin',
       });
 
       await utils.init();
-
-      // Add admin user via signup
-      await request(utils.app)
-        .post('/api/signup')
-        .send({
-          password: 'admin',
-          passwordConfirmation: 'admin',
-          email: 'admin@test.com',
-        })
-        .expect(200);
 
       // Add user via API using admin
       await request(utils.app)
@@ -137,19 +107,11 @@ describe('api/signin', function () {
   it('disabled user cannot log in', async function () {
     const utils = new TestUtil({
       authProxyEnabled: false,
+      admin: 'admin@test.com',
+      adminPassword: 'admin',
     });
 
     await utils.init();
-
-    // Add admin user via signup
-    await request(utils.app)
-      .post('/api/signup')
-      .send({
-        password: 'admin',
-        passwordConfirmation: 'admin',
-        email: 'admin@test.com',
-      })
-      .expect(200);
 
     // Add user via API using admin
     await request(utils.app)

--- a/server/test/api/signup.js
+++ b/server/test/api/signup.js
@@ -7,6 +7,7 @@ describe('api/signup', function () {
     const utils = new TestUtil({
       userpassAuthDisabled: 'true',
       authProxyEnabled: false,
+      admin: 'admin@test.com',
     });
 
     await utils.init();
@@ -24,6 +25,7 @@ describe('api/signup', function () {
   it('allows new user signup', async function () {
     const utils = new TestUtil({
       authProxyEnabled: false,
+      admin: 'admin@test.com',
     });
     await utils.init();
 
@@ -54,6 +56,7 @@ describe('api/signup', function () {
   it('prevents duplicate signups', async function () {
     const utils = new TestUtil({
       authProxyEnabled: false,
+      admin: 'admin@test.com',
     });
     await utils.init();
 


### PR DESCRIPTION
Closes #863 

From that issue:

Now that many auth methods are available, admin email/password may be set by config, and user authentication can be turned off all together, I think it would be good to drop the initial open-admin registration functionality.

This was initially added a long time ago to simplify setup. The idea was that you'd stand up a SQLPad server then log in to continue the process.

This no longer is the case today, as a majority of the config occurs before SQLPad is initially run.

Removing this functionality helps secure SQLPad for people that may start up a server and not realize admin registration might be open.