### PR TITLE
Add enhanced query sharing settings

### DIFF
--- a/client/src/common/Button.tsx
+++ b/client/src/common/Button.tsx
@@ -56,7 +56,7 @@ const Button = React.forwardRef<Ref, Props>(
         <button
           ref={ref}
           className={leftClassNames.join(' ')}
-          type={htmlType}
+          type={htmlType || 'button'}
           disabled={disabled}
           {...rest}
         >

--- a/client/src/common/IconButton.tsx
+++ b/client/src/common/IconButton.tsx
@@ -23,7 +23,17 @@ export type Ref = HTMLButtonElement;
 
 const IconButton = React.forwardRef<Ref, ButtonProps & LinkProps>(
   (
-    { children, variant, to, tooltip, disabled, className, onClick, ...rest },
+    {
+      children,
+      variant,
+      to,
+      tooltip,
+      disabled,
+      className,
+      onClick,
+      type,
+      ...rest
+    },
     ref
   ) => {
     const classNames = [styles.btn];
@@ -62,6 +72,7 @@ const IconButton = React.forwardRef<Ref, ButtonProps & LinkProps>(
     } else {
       button = (
         <button
+          type={type || 'button'}
           ref={ref}
           className={classNames.join(' ')}
           disabled={disabled}

--- a/client/src/common/Select.module.css
+++ b/client/src/common/Select.module.css
@@ -46,7 +46,7 @@
 .select[aria-disabled='true'] {
   color: graytext;
   background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100' fill='black'><polygon points='0,0 100,0 50,50'/></svg>"),
-    linear-gradient(to bottom, #ffffff 0%, #e5e5e5 100%);
+    linear-gradient(to bottom, #eee 0%, #eee 100%);
 }
 .select:disabled:hover,
 .select[aria-disabled='true'] {

--- a/client/src/queryEditor/ACLInput.tsx
+++ b/client/src/queryEditor/ACLInput.tsx
@@ -124,35 +124,34 @@ function ACLInput({ acl, onChange }: Props) {
               </option>
               {options}
             </Select>
-
-            {!isLastItem && (
-              <>
-                <HSpacer />
-                <Select
-                  value={readWrite}
-                  onChange={(event: ChangeEvent<HTMLSelectElement>) => {
-                    const { value } = event.target;
-                    const aclCopy = [...acl];
-                    const newWrite = value === 'write';
-                    aclCopy[index] = { groupId, userId, write: newWrite };
-                    onChange(aclCopy);
-                  }}
-                >
-                  <option value="readonly">View and execute</option>
-                  <option value="write">View, execute, and save</option>
-                </Select>
-                <HSpacer />
-                <IconButton
-                  onClick={() => {
-                    const first = acl.slice(0, index);
-                    const second = acl.slice(index + 1);
-                    onChange([...first, ...second]);
-                  }}
-                >
-                  <DeleteIcon />
-                </IconButton>
-              </>
-            )}
+            <HSpacer />
+            <Select
+              disabled={isLastItem}
+              value={readWrite}
+              onChange={(event: ChangeEvent<HTMLSelectElement>) => {
+                const { value } = event.target;
+                const aclCopy = [...acl];
+                const newWrite = value === 'write';
+                aclCopy[index] = { groupId, userId, write: newWrite };
+                onChange(aclCopy);
+              }}
+            >
+              <option value="readonly">
+                {isLastItem ? '' : 'View and execute'}
+              </option>
+              <option value="write">View, execute, and save</option>
+            </Select>
+            <HSpacer />
+            <IconButton
+              disabled={isLastItem}
+              onClick={() => {
+                const first = acl.slice(0, index);
+                const second = acl.slice(index + 1);
+                onChange([...first, ...second]);
+              }}
+            >
+              <DeleteIcon />
+            </IconButton>
           </div>
         );
       })}

--- a/client/src/queryEditor/ACLInput.tsx
+++ b/client/src/queryEditor/ACLInput.tsx
@@ -1,0 +1,95 @@
+import React, { ChangeEvent } from 'react';
+import Select from '../common/Select';
+import { ACLRecord } from '../types';
+import { api } from '../utilities/api';
+import useAppContext from '../utilities/use-app-context';
+
+interface Props {
+  acl: Partial<ACLRecord>[];
+  onChange: (value: Partial<ACLRecord>[]) => void;
+}
+
+function ACLInput({ acl, onChange }: Props) {
+  const { data: users } = api.useUsers();
+  const { currentUser } = useAppContext();
+
+  if (!users) {
+    return null;
+  }
+
+  function handleNewSelectChange(event: ChangeEvent<HTMLSelectElement>) {
+    const { value } = event.target;
+    if (value === '__EVERYONE__') {
+      onChange(acl.concat([{ groupId: '__EVERYONE__' }]));
+    } else if (value) {
+      onChange(acl.concat([{ userId: value }]));
+    }
+  }
+
+  // __EVERYONE__ is a groupId, otherwise everything else are user ids
+  const options = [{ value: '__EVERYONE__', label: 'Everyone' }].concat(
+    users.map((user) => {
+      return { value: user.id, label: user.name || user.email };
+    })
+  );
+
+  // Index selected values for optimized selected checks
+  const selectedByValue: Record<string, boolean> = {};
+  (acl || []).forEach((item) => {
+    if (item.groupId) {
+      selectedByValue[item.groupId] = true;
+    } else if (item.userId) {
+      selectedByValue[item.userId] = true;
+    }
+  });
+
+  // Options to show must include
+  // * selected value
+  // * all unselected values
+  function getSelectOptions(selectedValue: string) {
+    return options
+      .filter(
+        (option) =>
+          option.value === selectedValue || !selectedByValue[option.value]
+      )
+      .map((o) => {
+        return (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        );
+      });
+  }
+
+  return (
+    <div>
+      {(acl || []).map((aclItem, index) => {
+        const value = aclItem.groupId || aclItem.userId;
+        return (
+          <Select
+            key={value}
+            value={value}
+            onChange={(event: ChangeEvent<HTMLSelectElement>) => {
+              const aclCopy = [...acl];
+              const { value } = event.target;
+              if (value === '__EVERYONE__') {
+                aclCopy[index] = { groupId: value };
+              } else if (value) {
+                aclCopy[index] = { userId: value };
+              }
+              onChange(aclCopy);
+            }}
+          >
+            {getSelectOptions(value || '')}
+          </Select>
+        );
+      })}
+      <Select value={''} onChange={handleNewSelectChange}>
+        <option value=""></option>
+        {getSelectOptions('')}
+      </Select>
+    </div>
+  );
+}
+
+export default ACLInput;

--- a/client/src/queryEditor/ACLInput.tsx
+++ b/client/src/queryEditor/ACLInput.tsx
@@ -151,9 +151,9 @@ function ACLInput({ acl, onChange }: Props) {
           changes.
         </p>
         <p>
-          In order to execute a shared query, the user must also have access to
-          the underlying connection. This is managed separately, and may only be
-          managed by an administrator.
+          To execute a shared query, the user must also have access to the
+          underlying connection. This is managed separately and requires admin
+          permissions.
         </p>
       </FormExplain>
     </div>

--- a/client/src/queryEditor/ACLInput.tsx
+++ b/client/src/queryEditor/ACLInput.tsx
@@ -26,7 +26,7 @@ function ACLInput({ acl, onChange }: Props) {
   }
 
   // __EVERYONE__ is a groupId, otherwise everything else are user ids
-  // The author of the query can be excluded from list option
+  // The author of the query should be excluded from list option
   const options = [{ value: EVERYONE_GROUP_ID, label: 'Everyone' }].concat(
     users
       .filter((user) => user.id !== query?.createdBy)
@@ -45,9 +45,7 @@ function ACLInput({ acl, onChange }: Props) {
     }
   });
 
-  // Options to show must include
-  // * selected value
-  // * all unselected values
+  // Options to show must include selected value + all unselected value
   function getSelectOptions(selectedValue: string) {
     return options
       .filter(
@@ -63,6 +61,7 @@ function ACLInput({ acl, onChange }: Props) {
       });
   }
 
+  // An empty row always added for adding additional groups/users
   const aclPlusEmpty = acl.concat([{ groupId: '', userId: '', write: false }]);
 
   return (

--- a/client/src/queryEditor/ACLInput.tsx
+++ b/client/src/queryEditor/ACLInput.tsx
@@ -70,6 +70,8 @@ function ACLInput({ acl, onChange }: Props) {
       });
   }
 
+  const aclPlusEmpty = acl.concat([{ groupId: '', userId: '', write: false }]);
+
   return (
     <div>
       <label>Sharing</label>
@@ -77,6 +79,8 @@ function ACLInput({ acl, onChange }: Props) {
         <div
           style={{
             padding: 16,
+            marginTop: 16,
+            marginBottom: 16,
             textAlign: 'center',
             backgroundColor: '#fafafa',
             border: '1px dotted #ddd',
@@ -87,14 +91,22 @@ function ACLInput({ acl, onChange }: Props) {
           </Text>
         </div>
       ) : null}
-      {acl.map((aclItem, index) => {
+      {aclPlusEmpty.map((aclItem, index) => {
         const { write, groupId, userId } = aclItem;
         const readWrite = write ? 'write' : 'readOnly';
         const value = groupId || userId;
+
+        const isLastItem = index + 1 === aclPlusEmpty.length;
+
+        // If there are no  options left, don't render a row
+        const options = getSelectOptions(value || '');
+        if (options.length === 0) {
+          return null;
+        }
+
         return (
-          <div key={value} style={{ display: 'flex', marginBottom: 8 }}>
+          <div key={index} style={{ display: 'flex', marginBottom: 8 }}>
             <Select
-              key={value}
               value={value}
               onChange={(event: ChangeEvent<HTMLSelectElement>) => {
                 const aclCopy = [...acl];
@@ -107,43 +119,44 @@ function ACLInput({ acl, onChange }: Props) {
                 onChange(aclCopy);
               }}
             >
-              {getSelectOptions(value || '')}
+              <option value="" disabled hidden>
+                Add access...
+              </option>
+              {options}
             </Select>
-            <HSpacer />
-            <Select
-              value={readWrite}
-              onChange={(event: ChangeEvent<HTMLSelectElement>) => {
-                const { value } = event.target;
-                const aclCopy = [...acl];
-                const newWrite = value === 'write';
-                aclCopy[index] = { groupId, userId, write: newWrite };
-                onChange(aclCopy);
-              }}
-            >
-              <option value="readonly">View and execute</option>
-              <option value="write">View, execute, and save</option>
-            </Select>
-            <HSpacer />
-            <IconButton
-              onClick={() => {
-                const first = acl.slice(0, index);
-                const second = acl.slice(index + 1);
-                onChange([...first, ...second]);
-              }}
-            >
-              <DeleteIcon />
-            </IconButton>
+
+            {!isLastItem && (
+              <>
+                <HSpacer />
+                <Select
+                  value={readWrite}
+                  onChange={(event: ChangeEvent<HTMLSelectElement>) => {
+                    const { value } = event.target;
+                    const aclCopy = [...acl];
+                    const newWrite = value === 'write';
+                    aclCopy[index] = { groupId, userId, write: newWrite };
+                    onChange(aclCopy);
+                  }}
+                >
+                  <option value="readonly">View and execute</option>
+                  <option value="write">View, execute, and save</option>
+                </Select>
+                <HSpacer />
+                <IconButton
+                  onClick={() => {
+                    const first = acl.slice(0, index);
+                    const second = acl.slice(index + 1);
+                    onChange([...first, ...second]);
+                  }}
+                >
+                  <DeleteIcon />
+                </IconButton>
+              </>
+            )}
           </div>
         );
       })}
 
-      <label>
-        Add access
-        <Select placeholder="test" value={''} onChange={handleNewSelectChange}>
-          <option value=""></option>
-          {getSelectOptions('')}
-        </Select>
-      </label>
       <FormExplain>
         <p>
           When a query is shared with view/execute access, the user may alter

--- a/client/src/queryEditor/ACLInput.tsx
+++ b/client/src/queryEditor/ACLInput.tsx
@@ -1,8 +1,13 @@
+import DeleteIcon from 'mdi-react/DeleteIcon';
 import React, { ChangeEvent } from 'react';
+import FormExplain from '../common/FormExplain';
+import HSpacer from '../common/HSpacer';
+import IconButton from '../common/IconButton';
 import Select from '../common/Select';
+import Text from '../common/Text';
+import { useSessionQueryId } from '../stores/editor-store';
 import { ACLRecord } from '../types';
 import { api } from '../utilities/api';
-import useAppContext from '../utilities/use-app-context';
 
 interface Props {
   acl: Partial<ACLRecord>[];
@@ -11,9 +16,10 @@ interface Props {
 
 function ACLInput({ acl, onChange }: Props) {
   const { data: users } = api.useUsers();
-  const { currentUser } = useAppContext();
+  const queryId = useSessionQueryId();
+  const { data: query } = api.useQuery(queryId);
 
-  if (!users) {
+  if (!users || !query) {
     return null;
   }
 
@@ -27,15 +33,18 @@ function ACLInput({ acl, onChange }: Props) {
   }
 
   // __EVERYONE__ is a groupId, otherwise everything else are user ids
+  // The author of the query can be excluded from list option
   const options = [{ value: '__EVERYONE__', label: 'Everyone' }].concat(
-    users.map((user) => {
-      return { value: user.id, label: user.name || user.email };
-    })
+    users
+      .filter((user) => user.id !== query?.createdBy)
+      .map((user) => {
+        return { value: user.id, label: user.name || user.email };
+      })
   );
 
   // Index selected values for optimized selected checks
   const selectedByValue: Record<string, boolean> = {};
-  (acl || []).forEach((item) => {
+  acl.forEach((item) => {
     if (item.groupId) {
       selectedByValue[item.groupId] = true;
     } else if (item.userId) {
@@ -63,31 +72,90 @@ function ACLInput({ acl, onChange }: Props) {
 
   return (
     <div>
-      {(acl || []).map((aclItem, index) => {
-        const value = aclItem.groupId || aclItem.userId;
+      <label>Sharing</label>
+      {acl.length === 0 ? (
+        <div
+          style={{
+            padding: 16,
+            textAlign: 'center',
+            backgroundColor: '#fafafa',
+            border: '1px dotted #ddd',
+          }}
+        >
+          <Text>
+            Only query author or an admin may view, execute, and save changes.
+          </Text>
+        </div>
+      ) : null}
+      {acl.map((aclItem, index) => {
+        const { write, groupId, userId } = aclItem;
+        const readWrite = write ? 'write' : 'readOnly';
+        const value = groupId || userId;
         return (
-          <Select
-            key={value}
-            value={value}
-            onChange={(event: ChangeEvent<HTMLSelectElement>) => {
-              const aclCopy = [...acl];
-              const { value } = event.target;
-              if (value === '__EVERYONE__') {
-                aclCopy[index] = { groupId: value };
-              } else if (value) {
-                aclCopy[index] = { userId: value };
-              }
-              onChange(aclCopy);
-            }}
-          >
-            {getSelectOptions(value || '')}
-          </Select>
+          <div key={value} style={{ display: 'flex', marginBottom: 8 }}>
+            <Select
+              key={value}
+              value={value}
+              onChange={(event: ChangeEvent<HTMLSelectElement>) => {
+                const aclCopy = [...acl];
+                const { value } = event.target;
+                if (value === '__EVERYONE__') {
+                  aclCopy[index] = { groupId: value, write };
+                } else if (value) {
+                  aclCopy[index] = { userId: value, write };
+                }
+                onChange(aclCopy);
+              }}
+            >
+              {getSelectOptions(value || '')}
+            </Select>
+            <HSpacer />
+            <Select
+              value={readWrite}
+              onChange={(event: ChangeEvent<HTMLSelectElement>) => {
+                const { value } = event.target;
+                const aclCopy = [...acl];
+                const newWrite = value === 'write';
+                aclCopy[index] = { groupId, userId, write: newWrite };
+                onChange(aclCopy);
+              }}
+            >
+              <option value="readonly">View and execute</option>
+              <option value="write">View, execute, and save</option>
+            </Select>
+            <HSpacer />
+            <IconButton
+              onClick={() => {
+                const first = acl.slice(0, index);
+                const second = acl.slice(index + 1);
+                onChange([...first, ...second]);
+              }}
+            >
+              <DeleteIcon />
+            </IconButton>
+          </div>
         );
       })}
-      <Select value={''} onChange={handleNewSelectChange}>
-        <option value=""></option>
-        {getSelectOptions('')}
-      </Select>
+
+      <label>
+        Add access
+        <Select placeholder="test" value={''} onChange={handleNewSelectChange}>
+          <option value=""></option>
+          {getSelectOptions('')}
+        </Select>
+      </label>
+      <FormExplain>
+        <p>
+          When a query is shared with view/execute access, the user may alter
+          the query prior to execution, but will not be able to save those
+          changes.
+        </p>
+        <p>
+          In order to execute a shared query, the user must also have access to
+          the underlying connection. This is managed separately, and may only be
+          managed by an administrator.
+        </p>
+      </FormExplain>
     </div>
   );
 }

--- a/client/src/queryEditor/ACLInput.tsx
+++ b/client/src/queryEditor/ACLInput.tsx
@@ -14,6 +14,8 @@ interface Props {
   onChange: (value: Partial<ACLRecord>[]) => void;
 }
 
+const EVERYONE_GROUP_ID = '__EVERYONE__';
+
 function ACLInput({ acl, onChange }: Props) {
   const { data: users } = api.useUsers();
   const queryId = useSessionQueryId();
@@ -23,18 +25,9 @@ function ACLInput({ acl, onChange }: Props) {
     return null;
   }
 
-  function handleNewSelectChange(event: ChangeEvent<HTMLSelectElement>) {
-    const { value } = event.target;
-    if (value === '__EVERYONE__') {
-      onChange(acl.concat([{ groupId: '__EVERYONE__' }]));
-    } else if (value) {
-      onChange(acl.concat([{ userId: value }]));
-    }
-  }
-
   // __EVERYONE__ is a groupId, otherwise everything else are user ids
   // The author of the query can be excluded from list option
-  const options = [{ value: '__EVERYONE__', label: 'Everyone' }].concat(
+  const options = [{ value: EVERYONE_GROUP_ID, label: 'Everyone' }].concat(
     users
       .filter((user) => user.id !== query?.createdBy)
       .map((user) => {
@@ -111,7 +104,7 @@ function ACLInput({ acl, onChange }: Props) {
               onChange={(event: ChangeEvent<HTMLSelectElement>) => {
                 const aclCopy = [...acl];
                 const { value } = event.target;
-                if (value === '__EVERYONE__') {
+                if (value === EVERYONE_GROUP_ID) {
                   aclCopy[index] = { groupId: value, write };
                 } else if (value) {
                   aclCopy[index] = { userId: value, write };

--- a/client/src/queryEditor/QuerySaveModal.tsx
+++ b/client/src/queryEditor/QuerySaveModal.tsx
@@ -21,9 +21,6 @@ import { ACLRecord } from '../types';
 import { api } from '../utilities/api';
 import ACLInput from './ACLInput';
 
-// TODO: Add option between updating existing query, or saving new query (maybe)
-// TODO: Enhance share options
-
 // Instead of modelling the data as it is in the editor session
 // a separate view model is used to track state
 // Session data converts to it, and on save it gets transformed back to expected format

--- a/client/src/queryEditor/QuerySaveModal.tsx
+++ b/client/src/queryEditor/QuerySaveModal.tsx
@@ -9,6 +9,7 @@ import Spacer from '../common/Spacer';
 import { saveQuery, toggleShowSave } from '../stores/editor-actions';
 import {
   EditorSession,
+  useSessionACL,
   useSessionIsSaving,
   useSessionQueryName,
   useSessionQueryShared,
@@ -17,7 +18,9 @@ import {
   useSessionTags,
   useShowSave,
 } from '../stores/editor-store';
+import { ACLRecord } from '../types';
 import { api } from '../utilities/api';
+import ACLInput from './ACLInput';
 
 // TODO: Add option between updating existing query, or saving new query (maybe)
 // TODO: Enhance share options
@@ -29,10 +32,12 @@ interface ViewModel {
   name: string;
   shared: 'shared' | 'private';
   tags: string[];
+  acl: Partial<ACLRecord>[];
 }
 
 function QuerySaveModal() {
   const showSave = useShowSave();
+  const originalAcl = useSessionACL();
   const originalShared = useSessionQueryShared();
   const originalTags = useSessionTags();
   const originalName = useSessionQueryName();
@@ -45,6 +50,7 @@ function QuerySaveModal() {
     name: originalName,
     shared: originalShared ? 'shared' : 'private',
     tags: originalTags || [],
+    acl: originalAcl || [],
   });
 
   function resetViewModel() {
@@ -52,6 +58,7 @@ function QuerySaveModal() {
       name: originalName,
       shared: originalShared ? 'shared' : 'private',
       tags: originalTags || [],
+      acl: originalAcl || [],
     });
   }
 
@@ -72,6 +79,13 @@ function QuerySaveModal() {
       tags: originalTags || [],
     }));
   }, [originalTags]);
+
+  useEffect(() => {
+    setViewModel((vm) => ({
+      ...vm,
+      acl: originalAcl || [],
+    }));
+  }, [originalAcl]);
 
   const error = showValidation && !viewModel.name.length;
 
@@ -192,6 +206,13 @@ function QuerySaveModal() {
         */}
 
         <Spacer />
+        <ACLInput
+          acl={viewModel.acl}
+          onChange={(acl) => {
+            console.log(acl);
+            setViewModel((vm) => ({ ...vm, acl }));
+          }}
+        />
 
         {saveError && <ErrorBlock>{saveError}</ErrorBlock>}
 

--- a/client/src/queryEditor/QuerySaveModal.tsx
+++ b/client/src/queryEditor/QuerySaveModal.tsx
@@ -151,7 +151,6 @@ function QuerySaveModal() {
         <ACLInput
           acl={viewModel.acl}
           onChange={(acl) => {
-            console.log(acl);
             setViewModel((vm) => ({ ...vm, acl }));
           }}
         />
@@ -172,7 +171,6 @@ function QuerySaveModal() {
             style={{ width: '50%' }}
             variant="primary"
             disabled={isSaving || Boolean(error)}
-            onClick={() => handleSaveRequest()}
           >
             Save
           </Button>

--- a/client/src/stores/editor-actions.ts
+++ b/client/src/stores/editor-actions.ts
@@ -451,7 +451,7 @@ export const saveQuery = async (additionalUpdates?: Partial<EditorSession>) => {
   };
 
   if (queryId) {
-    api.put(`/api/queries/${queryId}`, queryData).then((json) => {
+    api.updateQuery(queryId, queryData).then((json) => {
       const { error, data } = json;
       if (error) {
         // If there was an error, show the save dialog.
@@ -461,7 +461,11 @@ export const saveQuery = async (additionalUpdates?: Partial<EditorSession>) => {
         setState({ showSave: true });
         return;
       }
-      api.reloadQueries();
+      // TODO - need to figure out how to express either { error } or { data }
+      // This would never happen but TypeScript doesn't know
+      if (!data) {
+        return;
+      }
       removeLocalQueryText(data.id);
       setSession({
         isSaving: false,
@@ -480,7 +484,7 @@ export const saveQuery = async (additionalUpdates?: Partial<EditorSession>) => {
       setState({ showSave: false });
     });
   } else {
-    api.post(`/api/queries`, queryData).then((json) => {
+    api.createQuery(queryData).then((json) => {
       const { error, data } = json;
       if (error) {
         // If there was an error, show the save dialog.
@@ -490,7 +494,11 @@ export const saveQuery = async (additionalUpdates?: Partial<EditorSession>) => {
         setState({ showSave: true });
         return;
       }
-      api.reloadQueries();
+      // TODO - need to figure out how to express either { error } or { data }
+      // This would never happen but TypeScript doesn't know
+      if (!data) {
+        return;
+      }
       window.history.replaceState(
         {},
         data.name,

--- a/client/src/stores/editor-store.ts
+++ b/client/src/stores/editor-store.ts
@@ -146,6 +146,10 @@ export function useSessionQueryText() {
   return useEditorStore((s) => s.getSession().queryText);
 }
 
+export function useSessionACL() {
+  return useEditorStore((s) => s.getSession().acl);
+}
+
 export function useSessionShowValidation() {
   return useEditorStore((s) => s.getSession().showValidation);
 }

--- a/client/src/utilities/api.ts
+++ b/client/src/utilities/api.ts
@@ -150,12 +150,25 @@ export const api = {
     return this.get<Query[]>('/api/queries');
   },
 
+  useQuery(queryId?: string) {
+    return useSWR<QueryDetail>(queryId ? `/api/queries/${queryId}` : null);
+  },
+
   getQuery(queryId: string) {
     return this.get<QueryDetail>(`/api/queries/${queryId}`);
   },
 
-  reloadQueries() {
-    return mutate('/api/queries');
+  async createQuery(body: any) {
+    const query = await this.post<QueryDetail>(`/api/queries`, body);
+    mutate('/api/queries');
+    return query;
+  },
+
+  async updateQuery(queryId: string, body: any) {
+    const query = await this.put<QueryDetail>(`/api/queries/${queryId}`, body);
+    mutate(`/api/queries`);
+    mutate(`/api/queries/${queryId}`);
+    return query;
   },
 
   deleteQuery(queryId: string) {


### PR DESCRIPTION
Adds enhanced sharing config for a query beyond shared and not shared. The underlying APIs server side have been in place, but the UI has not yet leveraged them.

This might need some iteration. Not 100% sure what is obvious so I'm erring on the side of giving the user more information on screen to assist in decoding how sharing works in SQLPad.

![image](https://user-images.githubusercontent.com/303966/98384984-12b1a980-2014-11eb-804e-7620e04f432a.png)

![image](https://user-images.githubusercontent.com/303966/98385015-1fce9880-2014-11eb-8848-29d9706c3dd9.png)

