### PR TITLE
Use sessionId param to manage editor session state

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -23,6 +23,7 @@
     "@types/uuid": "^8.3.0",
     "d3": "^5.16.0",
     "downshift": "^6.0.6",
+    "history": "^4.10.1",
     "humanize-duration": "^3.24.0",
     "keymaster": "^1.6.2",
     "localforage": "^1.9.0",

--- a/client/src/QueryChartOnly.tsx
+++ b/client/src/QueryChartOnly.tsx
@@ -37,7 +37,7 @@ function QueryChartOnly({ queryId }: Props) {
   const { data: rows } = api.useStatementResults(statementId, status);
 
   useEffect(() => {
-    loadQuery(queryId).then(() => runQuery());
+    loadQuery(queryId, 'chart').then(() => runQuery());
   }, [queryId]);
 
   useEffect(() => {

--- a/client/src/QueryTableOnly.tsx
+++ b/client/src/QueryTableOnly.tsx
@@ -34,7 +34,7 @@ function QueryTableOnly({ queryId }: Props) {
   const incomplete = useStatementIncomplete(statementId);
 
   useEffect(() => {
-    loadQuery(queryId).then(() => runQuery());
+    loadQuery(queryId, 'table').then(() => runQuery());
   }, [queryId]);
 
   useEffect(() => {

--- a/client/src/Routes.tsx
+++ b/client/src/Routes.tsx
@@ -14,6 +14,7 @@ import QueryEditor from './queryEditor/QueryEditor';
 import QueryTableOnly from './QueryTableOnly';
 import SignIn from './SignIn';
 import SignUp from './SignUp';
+import { RegisterHistory } from './utilities/history';
 import useAppContext from './utilities/use-app-context';
 
 function Routes() {
@@ -35,6 +36,15 @@ function Routes() {
       <Switch>
         <Route exact path="/" render={redirectToNew} />
         <Route exact path="/queries" render={redirectToNew} />
+        <Route
+          exact
+          path="/queries/new"
+          render={({ match }) => (
+            <Authenticated>
+              <QueryEditor queryId={''} />
+            </Authenticated>
+          )}
+        />
         <Route
           exact
           path="/queries/:queryId"
@@ -74,6 +84,7 @@ function Routes() {
         />
         <Route render={() => <NotFound />} />
       </Switch>
+      <RegisterHistory />
     </Router>
   );
 }

--- a/client/src/Routes.tsx
+++ b/client/src/Routes.tsx
@@ -5,6 +5,7 @@ import {
   Route,
   Switch,
 } from 'react-router-dom';
+import { v4 as uuidv4 } from 'uuid';
 import Authenticated from './Authenticated';
 import NotFound from './NotFound';
 import PasswordReset from './PasswordReset';
@@ -36,13 +37,28 @@ function Routes() {
       <Switch>
         <Route exact path="/" render={redirectToNew} />
         <Route exact path="/queries" render={redirectToNew} />
+        <Route
+          exact
+          path="/queries/:queryId"
+          render={({ match }) => {
+            if (!currentUser) {
+              return <Redirect to={'/signin'} />;
+            }
+            const sessionId = uuidv4();
+            return (
+              <Redirect
+                to={`/queries/${match.params.queryId}/sessions/${sessionId}`}
+              />
+            );
+          }}
+        />
 
-        <Route exact path="/queries/new">
+        <Route exact path="/queries/new/sessions/:sessionId">
           <Authenticated>
             <QueryEditor />
           </Authenticated>
         </Route>
-        <Route exact path="/queries/:queryId">
+        <Route exact path="/queries/:queryId/sessions/:sessionId">
           <Authenticated>
             <QueryEditor />
           </Authenticated>

--- a/client/src/Routes.tsx
+++ b/client/src/Routes.tsx
@@ -36,24 +36,18 @@ function Routes() {
       <Switch>
         <Route exact path="/" render={redirectToNew} />
         <Route exact path="/queries" render={redirectToNew} />
-        <Route
-          exact
-          path="/queries/new"
-          render={() => (
-            <Authenticated>
-              <QueryEditor queryId={''} />
-            </Authenticated>
-          )}
-        />
-        <Route
-          exact
-          path="/queries/:queryId"
-          render={({ match }) => (
-            <Authenticated>
-              <QueryEditor queryId={match.params.queryId} />
-            </Authenticated>
-          )}
-        />
+
+        <Route exact path="/queries/new">
+          <Authenticated>
+            <QueryEditor />
+          </Authenticated>
+        </Route>
+        <Route exact path="/queries/:queryId">
+          <Authenticated>
+            <QueryEditor />
+          </Authenticated>
+        </Route>
+
         <Route
           exact
           path="/query-table/:queryId"

--- a/client/src/Routes.tsx
+++ b/client/src/Routes.tsx
@@ -39,7 +39,7 @@ function Routes() {
         <Route
           exact
           path="/queries/new"
-          render={({ match }) => (
+          render={() => (
             <Authenticated>
               <QueryEditor queryId={''} />
             </Authenticated>

--- a/client/src/app-header/ToolbarNewQueryButton.tsx
+++ b/client/src/app-header/ToolbarNewQueryButton.tsx
@@ -1,17 +1,22 @@
 import React from 'react';
-import Button from '../common/Button';
+import ButtonLink from '../common/ButtonLink';
 import { resetNewQuery } from '../stores/editor-actions';
 
+/**
+ * This component needs to reset the query on click because using the URL alone is not enough.
+ * The query needs to reset on /queries/new -> /queries/new, and the onClick ensures that
+ */
 function ToolbarNewQueryButton() {
   return (
-    <Button
+    <ButtonLink
       variant="ghost"
-      // TODO FIXME XXX: This was meant to be a buttonLink
-      // to="/queries/new"
-      onClick={() => resetNewQuery()}
+      to="/queries/new"
+      onClick={() => {
+        resetNewQuery();
+      }}
     >
       New
-    </Button>
+    </ButtonLink>
   );
 }
 

--- a/client/src/app-header/ToolbarNewQueryButton.tsx
+++ b/client/src/app-header/ToolbarNewQueryButton.tsx
@@ -4,7 +4,8 @@ import { resetNewQuery } from '../stores/editor-actions';
 
 /**
  * This component needs to reset the query on click because using the URL alone is not enough.
- * The query needs to reset on /queries/new -> /queries/new, and the onClick ensures that
+ * The query needs to reset on /queries/new -> /queries/new, and the onClick ensures that.
+ * TODO: Actually make it /queries/:queryId/session/:sessionId
  */
 function ToolbarNewQueryButton() {
   return (

--- a/client/src/app-header/ToolbarNewQueryButton.tsx
+++ b/client/src/app-header/ToolbarNewQueryButton.tsx
@@ -1,21 +1,12 @@
 import React from 'react';
 import ButtonLink from '../common/ButtonLink';
-import { resetNewQuery } from '../stores/editor-actions';
 
 /**
- * This component needs to reset the query on click because using the URL alone is not enough.
- * The query needs to reset on /queries/new -> /queries/new, and the onClick ensures that.
- * TODO: Actually make it /queries/:queryId/session/:sessionId
+ * This link leverages the redirect to generate a new sessionId
  */
 function ToolbarNewQueryButton() {
   return (
-    <ButtonLink
-      variant="ghost"
-      to="/queries/new"
-      onClick={() => {
-        resetNewQuery();
-      }}
-    >
+    <ButtonLink variant="ghost" to="/queries/new">
       New
     </ButtonLink>
   );

--- a/client/src/queryEditor/DocumentTitle.ts
+++ b/client/src/queryEditor/DocumentTitle.ts
@@ -9,7 +9,7 @@ import { useSessionQueryName } from '../stores/editor-store';
  */
 function DocumentTitle({ queryId }: { queryId: string }) {
   const queryName = useSessionQueryName();
-  const title = queryId === 'new' ? 'New query' : queryName;
+  const title = queryId === '' ? 'New query' : queryName;
 
   useEffect(() => {
     document.title = title;

--- a/client/src/queryEditor/QueryEditor.tsx
+++ b/client/src/queryEditor/QueryEditor.tsx
@@ -18,10 +18,15 @@ import Shortcuts from './Shortcuts';
 import Toolbar from './Toolbar';
 import UnsavedQuerySelector from './UnsavedQuerySelector';
 import QuerySaveModal from './QuerySaveModal';
+import queryString from 'query-string';
 
 type QueryEditorProps = {
   queryId: string;
 };
+
+interface ParsedQueryString {
+  clone?: string;
+}
 
 // TODO FIXME XXX - On 404 query not found, prompt user to start new or open existing query
 // In both cases load new, but latter opens queries list
@@ -29,15 +34,21 @@ type QueryEditorProps = {
 function QueryEditor(props: QueryEditorProps) {
   const { queryId } = props;
 
+  const qs: ParsedQueryString = queryString.parse(window.location.search);
+  const { clone } = qs;
+
   // Once initialized reset or load query on changes accordingly
+  // When cloning, do not reset the editor state as it will be managed by the clone button
+  // The clone could include changes made locally but not yet saved.
+  // This feels confusing and I wonder if others are confused as well
   useEffect(() => {
-    if (queryId === '') {
+    if (queryId === '' && !clone) {
       resetNewQuery();
       connectConnectionClient();
-    } else {
+    } else if (queryId) {
       loadQuery(queryId).then(() => connectConnectionClient());
     }
-  }, [queryId]);
+  }, [queryId, clone]);
 
   return (
     <div

--- a/client/src/queryEditor/QueryEditor.tsx
+++ b/client/src/queryEditor/QueryEditor.tsx
@@ -19,20 +19,21 @@ import Toolbar from './Toolbar';
 import UnsavedQuerySelector from './UnsavedQuerySelector';
 import QuerySaveModal from './QuerySaveModal';
 import queryString from 'query-string';
-
-type QueryEditorProps = {
-  queryId: string;
-};
+import { useParams } from 'react-router-dom';
 
 interface ParsedQueryString {
   clone?: string;
 }
 
+interface Params {
+  queryId?: string;
+}
+
 // TODO FIXME XXX - On 404 query not found, prompt user to start new or open existing query
 // In both cases load new, but latter opens queries list
 
-function QueryEditor(props: QueryEditorProps) {
-  const { queryId } = props;
+function QueryEditor() {
+  const { queryId = '' } = useParams<Params>();
 
   const qs: ParsedQueryString = queryString.parse(window.location.search);
   const { clone } = qs;

--- a/client/src/queryEditor/QueryEditor.tsx
+++ b/client/src/queryEditor/QueryEditor.tsx
@@ -20,10 +20,6 @@ import UnsavedQuerySelector from './UnsavedQuerySelector';
 import QuerySaveModal from './QuerySaveModal';
 import { useParams } from 'react-router-dom';
 
-interface ParsedQueryString {
-  clone?: string;
-}
-
 interface Params {
   queryId?: string;
   sessionId: string;

--- a/client/src/queryEditor/QueryEditor.tsx
+++ b/client/src/queryEditor/QueryEditor.tsx
@@ -31,7 +31,7 @@ function QueryEditor(props: QueryEditorProps) {
 
   // Once initialized reset or load query on changes accordingly
   useEffect(() => {
-    if (queryId === 'new') {
+    if (queryId === '') {
       resetNewQuery();
       connectConnectionClient();
     } else {

--- a/client/src/queryEditor/QueryEditor.tsx
+++ b/client/src/queryEditor/QueryEditor.tsx
@@ -18,7 +18,6 @@ import Shortcuts from './Shortcuts';
 import Toolbar from './Toolbar';
 import UnsavedQuerySelector from './UnsavedQuerySelector';
 import QuerySaveModal from './QuerySaveModal';
-import queryString from 'query-string';
 import { useParams } from 'react-router-dom';
 
 interface ParsedQueryString {
@@ -27,29 +26,24 @@ interface ParsedQueryString {
 
 interface Params {
   queryId?: string;
+  sessionId: string;
 }
 
 // TODO FIXME XXX - On 404 query not found, prompt user to start new or open existing query
 // In both cases load new, but latter opens queries list
 
 function QueryEditor() {
-  const { queryId = '' } = useParams<Params>();
-
-  const qs: ParsedQueryString = queryString.parse(window.location.search);
-  const { clone } = qs;
+  const { queryId = '', sessionId } = useParams<Params>();
 
   // Once initialized reset or load query on changes accordingly
-  // When cloning, do not reset the editor state as it will be managed by the clone button
-  // The clone could include changes made locally but not yet saved.
-  // This feels confusing and I wonder if others are confused as well
   useEffect(() => {
-    if (queryId === '' && !clone) {
-      resetNewQuery();
+    if (queryId === '') {
+      resetNewQuery(sessionId);
       connectConnectionClient();
     } else if (queryId) {
-      loadQuery(queryId).then(() => connectConnectionClient());
+      loadQuery(queryId, sessionId).then(() => connectConnectionClient());
     }
-  }, [queryId, clone]);
+  }, [queryId, sessionId]);
 
   return (
     <div

--- a/client/src/queryEditor/UnsavedQuerySelector.tsx
+++ b/client/src/queryEditor/UnsavedQuerySelector.tsx
@@ -9,18 +9,32 @@ import {
   removeLocalQueryText,
 } from '../utilities/localQueryText';
 
-function UnsavedQuerySelector({ queryId }: any) {
+interface Props {
+  queryId: string;
+}
+
+/**
+ * TODO - if user edits a query they cannot save this shows a dialog and probably shouldn't
+ * Or should it clear on selection?
+ * @param Props
+ */
+function UnsavedQuerySelector({ queryId }: Props) {
   const queryText = useSessionQueryText();
   const [showModal, setShowModal] = useState(false);
   const [unsavedQueryText, setUnsavedQueryText] = useState('');
 
   useEffect(() => {
-    getLocalQueryText(queryId).then((localQueryText) => {
-      if (typeof localQueryText === 'string' && localQueryText.trim() !== '') {
-        setShowModal(true);
-        setUnsavedQueryText(localQueryText);
-      }
-    });
+    if (queryId) {
+      getLocalQueryText(queryId).then((localQueryText) => {
+        if (
+          typeof localQueryText === 'string' &&
+          localQueryText.trim() !== ''
+        ) {
+          setShowModal(true);
+          setUnsavedQueryText(localQueryText);
+        }
+      });
+    }
   }, [queryId]);
 
   const value = [queryText, unsavedQueryText];

--- a/client/src/stores/editor-actions.ts
+++ b/client/src/stores/editor-actions.ts
@@ -10,7 +10,7 @@ import {
   ConnectionClient,
 } from '../types';
 import { api } from '../utilities/api';
-import baseUrl from '../utilities/baseUrl';
+import { getHistory } from '../utilities/history';
 import {
   removeLocalQueryText,
   setLocalQueryText,
@@ -509,12 +509,8 @@ export const saveQuery = async (additionalUpdates?: Partial<EditorSession>) => {
       if (!data) {
         return;
       }
-      // TODO FIXME XXX this is not handled by react-router history
-      window.history.pushState(
-        {},
-        data.name,
-        `${baseUrl()}/queries/${data.id}`
-      );
+      const history = getHistory();
+      history?.push(`/queries/${data.id}`);
       removeLocalQueryText(data.id);
       setSession({
         isSaving: false,
@@ -539,8 +535,8 @@ export const saveQuery = async (additionalUpdates?: Partial<EditorSession>) => {
 export const handleCloneClick = () => {
   const { queryName } = getState().getSession();
   const newName = `Copy of ${queryName}`;
-  // TODO FIXME XXX this is not handled by react-router history
-  window.history.pushState({}, newName, `${baseUrl()}/queries/new`);
+  const history = getHistory();
+  history?.push(`/queries/new`);
   setSession({
     queryId: '',
     queryName: newName,

--- a/client/src/stores/editor-actions.ts
+++ b/client/src/stores/editor-actions.ts
@@ -31,11 +31,11 @@ const { getState, setState } = useEditorStore;
 
 function setSession(sessionId: string, update: Partial<EditorSession>) {
   const { editorSessions } = getState();
-  const focusedSession = getState().getSession(sessionId);
+  const session = getState().getSession(sessionId);
   setState({
     editorSessions: {
       ...editorSessions,
-      [sessionId]: { ...focusedSession, ...update },
+      [sessionId]: { ...session, ...update },
     },
   });
 }

--- a/client/src/stores/editor-actions.ts
+++ b/client/src/stores/editor-actions.ts
@@ -574,16 +574,15 @@ export const handleCloneClick = () => {
   history?.push(`/queries/new/sessions/${focusedSessionId}`);
 };
 
-// NOTE connectionId, connectionClient, etc ARE NOT set here on purpose
-// Some things should be carried over when creating a new session
-export const resetNewQuery = (sessionId: string) => {
+export const resetNewQuery = (newSessionId: string) => {
   const { focusedSessionId } = getState();
 
-  // Only change if sessionid is different from what is already loaded
-  if (focusedSessionId === sessionId) {
+  // Only proceed if newSessionId is different from what is already loaded
+  if (focusedSessionId === newSessionId) {
     return;
   }
 
+  // Get some editor state from current session and carry that on to new session
   const {
     showSchema,
     showVisProperties,
@@ -594,15 +593,15 @@ export const resetNewQuery = (sessionId: string) => {
 
   const session = {
     ...INITIAL_SESSION,
-    id: sessionId,
+    id: newSessionId,
     showSchema,
     showVisProperties,
     schemaExpansions,
     connectionId,
     connectionClient,
   };
-  setSession(sessionId, session);
-  setState({ focusedSessionId: sessionId });
+  setSession(newSessionId, session);
+  setState({ focusedSessionId: newSessionId });
 };
 
 export const selectStatementId = (selectedStatementId: string) => {

--- a/client/src/stores/editor-actions.ts
+++ b/client/src/stores/editor-actions.ts
@@ -533,18 +533,17 @@ export const saveQuery = async (additionalUpdates?: Partial<EditorSession>) => {
 };
 
 export const handleCloneClick = () => {
-  const { queryName } = getState().getSession();
-  const newName = `Copy of ${queryName}`;
+  const { queryName, queryId } = getState().getSession();
   const history = getHistory();
-  history?.push(`/queries/new`);
   setSession({
     queryId: '',
-    queryName: newName,
+    queryName: `Copy of ${queryName}`,
     unsavedChanges: true,
     canDelete: true,
     canWrite: true,
     canRead: true,
   });
+  history?.push(`/queries/new?clone=${queryId}`);
 };
 
 // NOTE connectionId, connectionClient, etc ARE NOT set here on purpose

--- a/client/src/stores/editor-actions.ts
+++ b/client/src/stores/editor-actions.ts
@@ -29,10 +29,7 @@ function sleep(ms: number) {
 
 const { getState, setState } = useEditorStore;
 
-function setSession(
-  sessionId: string,
-  update: Partial<EditorSession> | EditorSession
-) {
+function setSession(sessionId: string, update: Partial<EditorSession>) {
   const { editorSessions } = getState();
   const session = getState().getSession(sessionId);
   if (!session) {

--- a/client/src/stores/editor-actions.ts
+++ b/client/src/stores/editor-actions.ts
@@ -91,9 +91,9 @@ setInterval(async () => {
   }
 }, 10000);
 
-function setBatch(batchId: string, batch: Batch) {
-  const { batches, statements, focusedSessionId } = getState();
-  const { selectedStatementId } = getState().getFocusedSession();
+function setBatch(sessionId: string, batchId: string, batch: Batch) {
+  const { batches, statements } = getState();
+  const { selectedStatementId } = getState().getSession(sessionId) || {};
 
   const updatedStatements = {
     ...statements,
@@ -106,7 +106,7 @@ function setBatch(batchId: string, batch: Batch) {
     if (batch.statements.length === 1) {
       const onlyStatementId = batch.statements[0].id;
       if (selectedStatementId !== onlyStatementId) {
-        setSession(focusedSessionId, { selectedStatementId: onlyStatementId });
+        setSession(sessionId, { selectedStatementId: onlyStatementId });
       }
     }
   }
@@ -429,7 +429,7 @@ export const runQuery = async () => {
     });
   }
 
-  setBatch(batch.id, batch);
+  setBatch(focusedSessionId, batch.id, batch);
 
   while (
     batch?.id &&
@@ -446,7 +446,7 @@ export const runQuery = async () => {
     });
 
     if (batch) {
-      setBatch(batch.id, batch);
+      setBatch(focusedSessionId, batch.id, batch);
     }
   }
 

--- a/client/src/stores/editor-store.ts
+++ b/client/src/stores/editor-store.ts
@@ -57,7 +57,7 @@ export type EditorStoreState = {
   batches: Record<string, Batch>;
   statements: Record<string, Statement>;
   schemaStates: { [conectionId: string]: SchemaState };
-  getSession: () => EditorSession;
+  getSession: (sessionId?: string) => EditorSession;
 };
 
 export const INITIAL_SESSION_ID = 'initial';
@@ -104,12 +104,10 @@ export const useEditorStore = create<EditorStoreState>((set, get) => ({
   batches: {},
   statements: {},
   schemaStates: {},
-  getSession: () => {
+  getSession: (sessionId) => {
     const { focusedSessionId, editorSessions } = get();
-    if (!editorSessions[focusedSessionId]) {
-      throw new Error('Editor session not found');
-    }
-    return editorSessions[focusedSessionId];
+    const id = sessionId || focusedSessionId;
+    return editorSessions[id];
   },
 }));
 

--- a/client/src/stores/editor-store.ts
+++ b/client/src/stores/editor-store.ts
@@ -1,10 +1,10 @@
 import create from 'zustand';
 import {
-  ConnectionSchema,
-  ConnectionClient,
-  ChartFields,
   ACLRecord,
   Batch,
+  ChartFields,
+  ConnectionClient,
+  ConnectionSchema,
   Statement,
   StatementColumn,
 } from '../types';
@@ -250,7 +250,7 @@ export function useSessionSelectedStatementId() {
 export function useSessionSchemaExpanded(connectionId?: string) {
   return useEditorStore((s) => {
     const { schemaExpansions } = s.getSession();
-    if (!connectionId || !schemaExpansions[connectionId]) {
+    if (!connectionId || !schemaExpansions || !schemaExpansions[connectionId]) {
       return {};
     }
     return schemaExpansions[connectionId];

--- a/client/src/stores/editor-store.ts
+++ b/client/src/stores/editor-store.ts
@@ -57,7 +57,8 @@ export type EditorStoreState = {
   batches: Record<string, Batch>;
   statements: Record<string, Statement>;
   schemaStates: { [conectionId: string]: SchemaState };
-  getSession: (sessionId?: string) => EditorSession;
+  getFocusedSession: () => EditorSession;
+  getSession: (sessionId: string) => EditorSession | undefined;
 };
 
 export const INITIAL_SESSION_ID = 'initial';
@@ -104,10 +105,17 @@ export const useEditorStore = create<EditorStoreState>((set, get) => ({
   batches: {},
   statements: {},
   schemaStates: {},
-  getSession: (sessionId) => {
+  getFocusedSession: () => {
     const { focusedSessionId, editorSessions } = get();
-    const id = sessionId || focusedSessionId;
-    return editorSessions[id];
+    return editorSessions[focusedSessionId];
+  },
+  getSession: (sessionId) => {
+    const { editorSessions } = get();
+    const session = editorSessions[sessionId];
+    if (!session) {
+      return;
+    }
+    return session;
   },
 }));
 
@@ -121,90 +129,90 @@ export function useShowSave() {
 
 export function useSessionQueryShared() {
   return useEditorStore((s) => {
-    const { acl } = s.getSession();
+    const { acl } = s.getFocusedSession();
     return (acl || []).length > 0;
   });
 }
 
 export function useSessionSaveError() {
-  return useEditorStore((s) => s.getSession().saveError);
+  return useEditorStore((s) => s.getFocusedSession().saveError);
 }
 
 export function useSessionTags() {
-  return useEditorStore((s) => s.getSession().tags);
+  return useEditorStore((s) => s.getFocusedSession().tags);
 }
 
 export function useSessionQueryId() {
-  return useEditorStore((s) => s.getSession().queryId);
+  return useEditorStore((s) => s.getFocusedSession().queryId);
 }
 
 export function useSessionQueryName() {
-  return useEditorStore((s) => s.getSession().queryName);
+  return useEditorStore((s) => s.getFocusedSession().queryName);
 }
 
 export function useSessionQueryText() {
-  return useEditorStore((s) => s.getSession().queryText);
+  return useEditorStore((s) => s.getFocusedSession().queryText);
 }
 
 export function useSessionACL() {
-  return useEditorStore((s) => s.getSession().acl);
+  return useEditorStore((s) => s.getFocusedSession().acl);
 }
 
 export function useSessionShowValidation() {
-  return useEditorStore((s) => s.getSession().showValidation);
+  return useEditorStore((s) => s.getFocusedSession().showValidation);
 }
 
 export function useSessionIsRunning() {
-  return useEditorStore((s) => s.getSession().isRunning);
+  return useEditorStore((s) => s.getFocusedSession().isRunning);
 }
 
 export function useSessionIsSaving() {
-  return useEditorStore((s) => s.getSession().isSaving);
+  return useEditorStore((s) => s.getFocusedSession().isSaving);
 }
 
 export function useSessionUnsavedChanges() {
-  return useEditorStore((s) => s.getSession().unsavedChanges);
+  return useEditorStore((s) => s.getFocusedSession().unsavedChanges);
 }
 
 export function useSessionCanWrite() {
-  return useEditorStore((s) => s.getSession().canWrite);
+  return useEditorStore((s) => s.getFocusedSession().canWrite);
 }
 
 export function useSessionConnectionId(): string {
-  return useEditorStore((s) => s.getSession().connectionId);
+  return useEditorStore((s) => s.getFocusedSession().connectionId);
 }
 
 export function useSessionConnectionClient() {
-  return useEditorStore((s) => s.getSession().connectionClient);
+  return useEditorStore((s) => s.getFocusedSession().connectionClient);
 }
 
 export function useSessionConnectionClientId() {
-  return useEditorStore((s) => s.getSession().connectionClient?.id);
+  return useEditorStore((s) => s.getFocusedSession().connectionClient?.id);
 }
 
 export function useSessionShowSchema() {
-  return useEditorStore((s) => s.getSession().showSchema);
+  return useEditorStore((s) => s.getFocusedSession().showSchema);
 }
 
 export function useSessionShowVisProperties() {
-  return useEditorStore((s) => s.getSession().showVisProperties);
+  return useEditorStore((s) => s.getFocusedSession().showVisProperties);
 }
 
 export function useSessionChartType() {
-  return useEditorStore((s) => s.getSession().chartType);
+  return useEditorStore((s) => s.getFocusedSession().chartType);
 }
 
 export function useSessionChartFields() {
-  return useEditorStore((s) => s.getSession().chartFields);
+  return useEditorStore((s) => s.getFocusedSession().chartFields);
 }
 
 export function useSessionQueryResult() {
-  return useEditorStore((s) => s.getSession().queryResult);
+  return useEditorStore((s) => s.getFocusedSession().queryResult);
 }
 
 export function useSessionQueryError() {
   return useEditorStore((s) => {
-    const { queryError, selectedStatementId } = s.getSession();
+    const { queryError, selectedStatementId } = s.getFocusedSession();
     if (queryError) {
       return queryError;
     }
@@ -220,7 +228,7 @@ export function useSessionQueryError() {
 
 export function useBatchError() {
   return useEditorStore((s) => {
-    const { queryError, batchId } = s.getSession();
+    const { queryError, batchId } = s.getFocusedSession();
     if (queryError) {
       return queryError;
     }
@@ -240,16 +248,16 @@ export function useBatchError() {
 }
 
 export function useSessionRunQueryStartTime() {
-  return useEditorStore((s) => s.getSession().runQueryStartTime);
+  return useEditorStore((s) => s.getFocusedSession().runQueryStartTime);
 }
 
 export function useSessionSelectedStatementId() {
-  return useEditorStore((s) => s.getSession().selectedStatementId);
+  return useEditorStore((s) => s.getFocusedSession().selectedStatementId);
 }
 
 export function useSessionSchemaExpanded(connectionId?: string) {
   return useEditorStore((s) => {
-    const { schemaExpansions } = s.getSession();
+    const { schemaExpansions } = s.getFocusedSession();
     if (!connectionId || !schemaExpansions || !schemaExpansions[connectionId]) {
       return {};
     }
@@ -272,7 +280,7 @@ export function useSchemaState(connectionId?: string) {
  */
 export function useSessionBatch() {
   return useEditorStore((s) => {
-    const { batchId } = s.getSession();
+    const { batchId } = s.getFocusedSession();
     if (batchId) {
       const batch = s.batches[batchId];
       if (batch) {
@@ -284,7 +292,7 @@ export function useSessionBatch() {
 
 export function useLastStatementId() {
   return useEditorStore((s) => {
-    const { batchId } = s.getSession();
+    const { batchId } = s.getFocusedSession();
     if (batchId) {
       const batch = s.batches[batchId];
       if (batch && batch.statements) {
@@ -300,7 +308,7 @@ export function useLastStatementId() {
 
 export function useSessionTableLink(sequence?: number) {
   return useEditorStore((s) => {
-    const { queryId, connectionClient } = s.getSession();
+    const { queryId, connectionClient } = s.getFocusedSession();
     const connectionClientId = connectionClient?.id;
 
     let tableLink = '';
@@ -331,7 +339,7 @@ export function useSessionTableLink(sequence?: number) {
  */
 export function useSessionStatementIdBySequence(sequence?: number) {
   return useEditorStore((s) => {
-    const { batchId } = s.getSession();
+    const { batchId } = s.getFocusedSession();
     if (batchId) {
       const batch = s.batches[batchId];
       if (batch && batch.statements) {

--- a/client/src/utilities/history.ts
+++ b/client/src/utilities/history.ts
@@ -1,0 +1,19 @@
+import { History } from 'history';
+import { useHistory } from 'react-router-dom';
+
+let _history: History | undefined = undefined;
+
+export function getHistory() {
+  return _history;
+}
+
+/**
+ * Component to capture history from a hook and store in variable.
+ */
+export function RegisterHistory() {
+  const history = useHistory();
+  if (!_history) {
+    _history = history;
+  }
+  return null;
+}


### PR DESCRIPTION
Fixes a few bugs around cloning and creating new queries, relating to how the client-side router works with browser history state. The URL and editor state could become out of sync, requiring navigating away from a query and then back to it to get the URL to be as expected.

To solve these issues, any history altering uses the `history` instance from `react-router-dom`.  To obtain access to this in the editor state, a component is used to capture it on initial render.

To enable clearing the editor session state purely on routing however, an additional URL parameter is needed. This work also adds `/queries/:queryId/sessions/:sessionId` routes. SessionId maps to editorSession in state. When this value changes the session state is also changed (either loading a query identified by `:queryId` or clearing the editor state). 

The clone button leverages this by copying the current editor state into a new session, then navigating the user to `/queries/new/sessions/:sessionId`. Because the session is already established prior to the navigation, the loading based on route is skipped.