### PR TITLE
Remove sessions url parameter strategy

### DIFF
--- a/client/src/Routes.tsx
+++ b/client/src/Routes.tsx
@@ -5,14 +5,13 @@ import {
   Route,
   Switch,
 } from 'react-router-dom';
-import { v4 as uuidv4 } from 'uuid';
 import PasswordReset from './pages/PasswordReset';
 import PasswordResetRequested from './pages/PasswordResetRequested';
 import QueryChartOnly from './pages/QueryChartOnly';
+import QueryEditorWrapper from './pages/QueryEditorWrapper';
 import QueryTableOnly from './pages/QueryTableOnly';
 import SignIn from './pages/SignIn';
 import SignUp from './pages/SignUp';
-import QueryEditorWrapper from './pages/QueryEditorWrapper';
 import { RegisterHistory } from './utilities/history';
 import useAppContext from './utilities/use-app-context';
 
@@ -57,29 +56,12 @@ function Routes() {
   return (
     <Router basename={config.baseUrl}>
       <Switch>
-        {/* 
-          For queries URLs without sessions, generate a sessionId and redirect to it 
-          The session will be initialized within a useEffect
-        */}
-        <Route
-          exact
-          path="/queries/:queryIdOrNew"
-          render={({ match }) => {
-            const sessionId = uuidv4();
-            return (
-              <Redirect
-                to={`/queries/${match.params.queryIdOrNew}/sessions/${sessionId}`}
-              />
-            );
-          }}
-        />
-
-        {/* For /queries/new/... prevent a queryId from being captured via params */}
-        <Route exact path="/queries/new/sessions/:sessionId">
+        {/* For /queries/new prevent a queryId from being captured via params */}
+        <Route exact path="/queries/new">
           <QueryEditorWrapper />
         </Route>
 
-        <Route exact path="/queries/:queryId/sessions/:sessionId">
+        <Route exact path="/queries/:queryId">
           <QueryEditorWrapper />
         </Route>
 

--- a/client/src/app-header/ToolbarNewQueryButton.tsx
+++ b/client/src/app-header/ToolbarNewQueryButton.tsx
@@ -1,12 +1,34 @@
 import React from 'react';
 import ButtonLink from '../common/ButtonLink';
+import { resetNewQuery } from '../stores/editor-actions';
 
 /**
  * This link leverages the redirect to generate a new sessionId
  */
 function ToolbarNewQueryButton() {
   return (
-    <ButtonLink variant="ghost" to="/queries/new">
+    <ButtonLink
+      variant="ghost"
+      to="/queries/new"
+      onClick={(e) => {
+        // If user is trying to open another tab, let the browser do that
+        if (
+          e.ctrlKey ||
+          e.metaKey ||
+          e.altKey ||
+          e.shiftKey ||
+          e.button ||
+          e.defaultPrevented
+        ) {
+          return;
+        }
+
+        // Otherwise init a new query
+        // User could be going from new to new query, and it needs to be reset via function call
+        // We cannot rely on router to do this for us
+        resetNewQuery();
+      }}
+    >
       New
     </ButtonLink>
   );

--- a/client/src/pages/QueryChartOnly.tsx
+++ b/client/src/pages/QueryChartOnly.tsx
@@ -37,7 +37,7 @@ function QueryChartOnly({ queryId }: Props) {
   const { data: rows } = api.useStatementResults(statementId, status);
 
   useEffect(() => {
-    loadQuery(queryId, 'chart').then(() => runQuery());
+    loadQuery(queryId).then(() => runQuery());
   }, [queryId]);
 
   useEffect(() => {

--- a/client/src/pages/QueryTableOnly.tsx
+++ b/client/src/pages/QueryTableOnly.tsx
@@ -34,7 +34,7 @@ function QueryTableOnly({ queryId }: Props) {
   const incomplete = useStatementIncomplete(statementId);
 
   useEffect(() => {
-    loadQuery(queryId, 'table').then(() => runQuery());
+    loadQuery(queryId).then(() => runQuery());
   }, [queryId]);
 
   useEffect(() => {

--- a/client/src/queryEditor/QueryEditor.tsx
+++ b/client/src/queryEditor/QueryEditor.tsx
@@ -1,46 +1,43 @@
 import React, { useEffect } from 'react';
+import { useParams } from 'react-router-dom';
 import SplitPane from 'react-split-pane';
 import AppHeader from '../app-header/AppHeader';
 import { debouncedResizeChart } from '../common/tauChartRef';
 import SchemaInfoLoader from '../schema/SchemaInfoLoader';
-import {
-  connectConnectionClient,
-  loadQuery,
-  resetNewQuery,
-} from '../stores/editor-actions';
+import { connectConnectionClient, loadQuery } from '../stores/editor-actions';
+import useShortcuts from '../utilities/use-shortcuts';
 import DocumentTitle from './DocumentTitle';
 import EditorPaneRightSidebar from './EditorPaneRightSidebar';
 import EditorPaneSchemaSidebar from './EditorPaneSchemaSidebar';
 import EditorPaneVis from './EditorPaneVis';
 import QueryEditorResultPane from './QueryEditorResultPane';
 import QueryEditorSqlEditor from './QueryEditorSqlEditor';
-import useShortcuts from '../utilities/use-shortcuts';
+import QuerySaveModal from './QuerySaveModal';
 import Toolbar from './Toolbar';
 import UnsavedQuerySelector from './UnsavedQuerySelector';
-import QuerySaveModal from './QuerySaveModal';
-import { useParams } from 'react-router-dom';
 
 interface Params {
   queryId?: string;
-  sessionId: string;
 }
 
 // TODO FIXME XXX - On 404 query not found, prompt user to start new or open existing query
 // In both cases load new, but latter opens queries list
 
 function QueryEditor() {
-  const { queryId = '', sessionId } = useParams<Params>();
+  const { queryId = '' } = useParams<Params>();
   useShortcuts();
 
   // Once initialized reset or load query on changes accordingly
   useEffect(() => {
     if (queryId === '') {
-      resetNewQuery(sessionId);
+      // Calling resetNewQuery is not necessary here as it will either be initialized that way on load,
+      // or handled by the new query click in toolbar
+      // We should however ensure the connection client is established if needed
       connectConnectionClient();
     } else if (queryId) {
-      loadQuery(queryId, sessionId).then(() => connectConnectionClient());
+      loadQuery(queryId).then(() => connectConnectionClient());
     }
-  }, [queryId, sessionId]);
+  }, [queryId]);
 
   return (
     <div


### PR DESCRIPTION
Removes `/queries/<queryId>/sessions/<sessionId>` URL strategy for managing new/cloned queries. I don't know that I like it, and I think long term I'm not sure URLs are really that helpful for SQLPad. I instead see querystring parameters being more important in maintaining state? (For example, imaging being able to pass sql text, name, connection id all as querystring to have the editor open with what you need). 

Because I'm unsure of URL strategy, I figured keeping things the way they were is a better route to go instead of changing it (to add sessions) then changing it yet again.