### PR TITLE
Prompt user to start new query on query not found

### DIFF
--- a/client/src/queryEditor/NotFoundModal.tsx
+++ b/client/src/queryEditor/NotFoundModal.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import ButtonLink from '../common/ButtonLink';
+import Modal from '../common/Modal';
+import { resetNewQuery } from '../stores/editor-actions';
+
+export interface Props {
+  visible: boolean;
+  queryId: string;
+}
+
+function NotFoundModal({ visible, queryId }: Props) {
+  return (
+    <Modal title="Query not found" width={'400px'} visible={visible}>
+      <p>
+        Query ID <code>{queryId}</code> not found. It may have been deleted or
+        you may not have access.
+      </p>
+      <ButtonLink
+        style={{ width: '100%', justifyContent: 'center' }}
+        variant="primary"
+        to="/queries/new"
+        onClick={() => resetNewQuery()}
+      >
+        Start new query
+      </ButtonLink>
+    </Modal>
+  );
+}
+
+export default React.memo(NotFoundModal);

--- a/client/src/stores/editor-actions.ts
+++ b/client/src/stores/editor-actions.ts
@@ -314,10 +314,18 @@ export const formatQuery = async () => {
   });
 };
 
+/**
+ * Loads query and stores in editor session state.
+ * Returns a promise of API result to allow context-dependent behavior,
+ * like showing not found modal in query editor.
+ * @param queryId
+ */
 export const loadQuery = async (queryId: string) => {
-  const { error, data } = await api.getQuery(queryId);
+  const response = await api.getQuery(queryId);
+
+  const { error, data } = response;
   if (error || !data) {
-    return message.error('Query not found');
+    return response;
   }
 
   const { focusedSessionId } = getState();
@@ -356,6 +364,8 @@ export const loadQuery = async (queryId: string) => {
     queryResult: undefined,
     unsavedChanges: false,
   });
+
+  return response;
 };
 
 export const runQuery = async () => {


### PR DESCRIPTION
Instead of posting an error message toast message, the user is prompted to start a new query. The modal stays visible and user is required to acknowledge what happened.

![image](https://user-images.githubusercontent.com/303966/99191687-dc6edb00-2733-11eb-8f6a-95d0dc0f8ee9.png)
