### PR TITLE
Simplify query list

### DIFF
--- a/client/src/queries/QueryList.module.css
+++ b/client/src/queries/QueryList.module.css
@@ -33,8 +33,10 @@
 }
 
 .queryLink {
-  width: 100%;
-  padding: 8px;
+  height: 46px;
+  line-height: 46px;
+  width: 500px;
+  padding-left: 4px;
 }
 
 .newWindowLink {

--- a/client/src/queries/QueryListDrawer.tsx
+++ b/client/src/queries/QueryListDrawer.tsx
@@ -1,4 +1,3 @@
-import OpenInNewIcon from 'mdi-react/OpenInNewIcon';
 import queryString from 'query-string';
 import React, { useCallback, useEffect, useState } from 'react';
 import Measure from 'react-measure';
@@ -16,7 +15,6 @@ import message from '../common/message';
 import MultiSelect, { MultiSelectItem } from '../common/MultiSelect';
 import Select from '../common/Select';
 import SpinKitCube from '../common/SpinKitCube';
-import Text from '../common/Text';
 import { Query } from '../types';
 import { api } from '../utilities/api';
 import styles from './QueryList.module.css';
@@ -144,11 +142,7 @@ function QueryListDrawer({ onClose, visible }: Props) {
 
   const Row = ({ index, style }: any) => {
     const query = queries[index];
-    const tableUrl = `/query-table/${query.id}`;
-    const chartUrl = `/query-chart/${query.id}`;
     const queryUrl = `/queries/${query.id}`;
-
-    const hasChart = query && query.chart && query.chart.chartType;
 
     return (
       <ListItem
@@ -158,45 +152,14 @@ function QueryListDrawer({ onClose, visible }: Props) {
         onMouseLeave={() => setPreview(null)}
         style={style}
       >
-        <Link className={styles.queryLink} to={queryUrl} onClick={handleClose}>
+        <Link
+          className={`${styles.queryLink} truncate`}
+          to={queryUrl}
+          onClick={handleClose}
+        >
           {query.name}
-          <br />
-          <Text type="secondary">{query.connection.name}</Text>
         </Link>
         <div className={styles.listItemActions}>
-          <Link
-            className={styles.newWindowLink}
-            to={tableUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            table <OpenInNewIcon size={16} />
-          </Link>
-          <div style={{ width: 8 }} />
-          {Boolean(hasChart) ? (
-            <Link
-              className={styles.newWindowLink}
-              to={chartUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              chart <OpenInNewIcon size={16} />
-            </Link>
-          ) : (
-            // this is a "disabled" link
-            <span
-              style={{
-                color: 'rgba(0, 0, 0, 0.25)',
-                cursor: 'not-allowed',
-                pointerEvents: 'none',
-                display: 'inline-flex',
-                alignItems: 'center',
-              }}
-            >
-              chart <OpenInNewIcon size={16} />
-            </span>
-          )}
-          <div style={{ width: 4 }} />
           <DeleteConfirmButton
             icon
             key="del"
@@ -331,7 +294,7 @@ function QueryListDrawer({ onClose, visible }: Props) {
                       onItemsRendered={onItemsRendered}
                       height={dimensions.height}
                       itemCount={queries.length}
-                      itemSize={60}
+                      itemSize={48}
                       width={dimensions.width}
                       overscanCount={2}
                     >


### PR DESCRIPTION
Removes table and chart links, along with connection name from query list. Doing so removes the visual clutter, hopefully aiding the user in scanning for the query they are looking for.

I can't speak for others, but here's where I've landed on the removals:

* The connection name aligned with query name became something I actively tried to ignore when scanning query names. If a reference to the connection name is needed, the user can refer to the preview on hover, or use the filter to narrow their search to queries targeting a specific database.
* The table/chart links were removed as I question their usefulness, particularly since the table/chart only pages require authentication. It also isn't clear why the chart link is greyed out. These links are still available on the table/chart once running the query, so the only loss here is the shortcut to going from query list to table/chart only views. 

I'd be open to reversing these changes if anyone has any strong reasons for doing so.

![image](https://user-images.githubusercontent.com/303966/99200888-afd7b500-276d-11eb-9f39-2da5737d9948.png)
