### PR TITLE
Fix document title not changing on sign in

### DIFF
--- a/client/src/queryEditor/DocumentTitle.ts
+++ b/client/src/queryEditor/DocumentTitle.ts
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { useSessionQueryName } from '../stores/editor-store';
 
 /**
@@ -10,9 +9,10 @@ function DocumentTitle({ queryId }: { queryId: string }) {
   const queryName = useSessionQueryName();
   const title = queryId === '' ? 'New query' : queryName;
 
-  useEffect(() => {
+  if (document.title !== title) {
+    console.log('updating title');
     document.title = title;
-  }, [title]);
+  }
 
   return null;
 }

--- a/client/src/queryEditor/DocumentTitle.ts
+++ b/client/src/queryEditor/DocumentTitle.ts
@@ -10,7 +10,6 @@ function DocumentTitle({ queryId }: { queryId: string }) {
   const title = queryId === '' ? 'New query' : queryName;
 
   if (document.title !== title) {
-    console.log('updating title');
     document.title = title;
   }
 


### PR DESCRIPTION
After signing in, the  new query editor opens but the document title still reads sign in. Setting document title doesn't actually need to be in a useEffect.