### PR TITLE
Show multi-line values in query results

### DIFF
--- a/client/src/common/QueryResultDataTable.module.css
+++ b/client/src/common/QueryResultDataTable.module.css
@@ -1,0 +1,67 @@
+/* 
+  Fancy CSS to apply a shadow when content is overflowing
+  Approach modified from https://codepen.io/matthewbeta/pen/fzoHI
+*/
+.scrollboxEven {
+  background-image: 
+    /* Shadows */ linear-gradient(
+      to right,
+      rgb(250, 250, 250),
+      rgb(250, 250, 250)
+    ),
+    linear-gradient(to right, rgb(250, 250, 250), rgb(250, 250, 250)),
+    /* Shadow covers */
+      linear-gradient(to right, rgba(0, 0, 0, 0.25), rgba(255, 255, 255, 0)),
+    linear-gradient(to left, rgba(0, 0, 0, 0.25), rgba(255, 255, 255, 0));
+
+  background-position: left center, right center, left center, right center;
+  background-repeat: no-repeat;
+  background-color: rgb(250, 250, 250);
+  background-size: 20px 100%, 20px 100%, 10px 100%, 10px 100%;
+
+  /* Opera doesn't support this in the shorthand */
+  background-attachment: local, local, scroll, scroll;
+}
+
+.scrollboxOdd {
+  background-image: 
+    /* Shadows */ linear-gradient(to right, white, white),
+    linear-gradient(to right, white, white),
+    /* Shadow covers */
+      linear-gradient(to right, rgba(0, 0, 0, 0.25), rgba(255, 255, 255, 0)),
+    linear-gradient(to left, rgba(0, 0, 0, 0.25), rgba(255, 255, 255, 0));
+
+  background-position: left center, right center, left center, right center;
+  background-repeat: no-repeat;
+  background-color: white;
+  background-size: 20px 100%, 20px 100%, 10px 100%, 10px 100%;
+
+  /* Opera doesn't support this in the shorthand */
+  background-attachment: local, local, scroll, scroll;
+}
+
+.faderEven {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 16px;
+  background-image: linear-gradient(
+    to right,
+    rgba(255, 0, 0, 0),
+    rgb(250, 250, 250)
+  );
+}
+
+.faderOdd {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 16px;
+  background-image: linear-gradient(
+    to right,
+    rgba(255, 0, 0, 0),
+    rgb(255, 255, 255)
+  );
+}

--- a/client/src/common/QueryResultDataTable.module.css
+++ b/client/src/common/QueryResultDataTable.module.css
@@ -3,6 +3,8 @@
   Approach modified from https://codepen.io/matthewbeta/pen/fzoHI
 */
 .scrollboxEven {
+  display: flex;
+  flex-wrap: nowrap;
   background-image: 
     /* Shadows */ linear-gradient(
       to right,
@@ -17,13 +19,15 @@
   background-position: left center, right center, left center, right center;
   background-repeat: no-repeat;
   background-color: rgb(250, 250, 250);
-  background-size: 20px 100%, 20px 100%, 10px 100%, 10px 100%;
+  background-size: 10px 100%, 10px 100%, 10px 100%, 10px 100%;
 
   /* Opera doesn't support this in the shorthand */
   background-attachment: local, local, scroll, scroll;
 }
 
 .scrollboxOdd {
+  display: flex;
+  flex-wrap: nowrap;
   background-image: 
     /* Shadows */ linear-gradient(to right, white, white),
     linear-gradient(to right, white, white),
@@ -34,10 +38,30 @@
   background-position: left center, right center, left center, right center;
   background-repeat: no-repeat;
   background-color: white;
-  background-size: 20px 100%, 20px 100%, 10px 100%, 10px 100%;
+  background-size: 10px 100%, 10px 100%, 10px 100%, 10px 100%;
 
   /* Opera doesn't support this in the shorthand */
   background-attachment: local, local, scroll, scroll;
+}
+
+.cellValue {
+  flex-shrink: 0;
+  line-height: 22px;
+  overflow: hidden;
+  color: rgba(0, 0, 0, 0.65);
+  font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro',
+    monospace;
+}
+
+/* 
+  The important thing about this placeholder is that it is hidden
+  It needs to take up space but not be visible
+*/
+.hiddenPlaceholder {
+  visibility: hidden;
+  display: block;
+  width: 20px;
+  height: 100%;
 }
 
 .faderEven {

--- a/client/src/common/QueryResultDataTable.tsx
+++ b/client/src/common/QueryResultDataTable.tsx
@@ -285,10 +285,23 @@ class QueryResultDataTable extends React.PureComponent<
     if (column) {
       const value = rows?.[rowIndex]?.[columnIndex];
       return (
-        <pre className={scrollboxClass} style={finalStyle}>
-          {renderValue(value, column)}
+        <div className={scrollboxClass} style={finalStyle}>
+          <pre className={styles.cellValue}>{renderValue(value, column)}</pre>
+          {/* 
+            this placeholder is hidden content that helps the overflow shadow work.
+            Without this 10px of content needs to overflow before.
+            Unfortunately it looks like actual content is needed for overflow, so the "x" is that content.
+            Two letters seems to be a bit too much. 
+            Is there not a way to have empty space count as content for overflow purposes?
+            Something seems off about this.
+          */}
+          <div className={styles.hiddenPlaceholder}>x</div>
+          {/* 
+            Absolutely positioned fader to fade content out.
+            Was initially going to be instead of the shadow, but using both provide a subtle look thats kinda nice.
+          */}
           <div className={faderClass}></div>
-        </pre>
+        </div>
       );
     }
 

--- a/client/src/common/QueryResultDataTable.tsx
+++ b/client/src/common/QueryResultDataTable.tsx
@@ -4,6 +4,7 @@ import throttle from 'lodash/throttle';
 import Draggable from 'react-draggable';
 import Measure from 'react-measure';
 import { StatementColumn, StatementResults } from '../types';
+import styles from './QueryResultDataTable.module.css';
 
 interface FieldMeta {
   datatype: string;
@@ -257,14 +258,24 @@ class QueryResultDataTable extends React.PureComponent<
     const { columns, rows } = this.props;
     const column = columns[columnIndex];
     const finalStyle = Object.assign({}, style, cellStyle);
+
+    let scrollboxClass = styles.scrollboxOdd;
+    let faderClass = styles.faderOdd;
     if (rowIndex % 2 === 0) {
       finalStyle.backgroundColor = '#fafafa';
+      scrollboxClass = styles.scrollboxEven;
+      faderClass = styles.faderEven;
     }
 
     // If dataKey is present this is a real data cell to render
     if (column) {
       const value = rows?.[rowIndex]?.[columnIndex];
-      return <pre style={finalStyle}>{renderValue(value, column)}</pre>;
+      return (
+        <pre className={scrollboxClass} style={finalStyle}>
+          {renderValue(value, column)}
+          <div className={faderClass}></div>
+        </pre>
+      );
     }
 
     // If no dataKey this is a dummy cell.

--- a/client/src/common/QueryResultDataTable.tsx
+++ b/client/src/common/QueryResultDataTable.tsx
@@ -115,8 +115,8 @@ class QueryResultDataTable extends React.PureComponent<
   componentDidUpdate = (prevProps: QueryResultDataTableProps) => {
     const { columns } = this.props;
     const { columnWidths } = this.state;
-    // TODO - take width into consideration for column sizes if few cols are used
-    // const { height, width } = this.state.dimensions;
+
+    const { width } = this.state.dimensions;
 
     let newInitialColumn = false;
 
@@ -125,6 +125,16 @@ class QueryResultDataTable extends React.PureComponent<
         const { name, maxValueLength } = column;
         if (!columnWidths[name]) {
           newInitialColumn = true;
+
+          // If this is the only column, give it the entire width minus 40px
+          // The 40px accounts for scrollbar + spare column
+          // Also serves as a visual reminder/remains visually consistent with other tables that have empty spare column
+          if (columns.length === 1) {
+            const almostAll = Math.floor(width) - 40;
+            columnWidths[name] = almostAll;
+            return;
+          }
+
           // (This length is number of characters -- it later gets assigned ~ 20px per char)
           let valueLength = maxValueLength || 8;
 
@@ -162,12 +172,16 @@ class QueryResultDataTable extends React.PureComponent<
     const { width } = dimensions;
 
     if (column) {
-      return columnWidths[column.name];
+      return columnWidths[column.name] || 0;
     }
 
     const totalWidthFilled = columns
       .map((col) => columnWidths[col.name])
       .reduce((prev: number, curr: number) => prev + curr, 0);
+
+    if (isNaN(totalWidthFilled)) {
+      return 0;
+    }
 
     const fakeColumnWidth = width - totalWidthFilled - scrollbarWidth;
     return fakeColumnWidth < 10 ? 10 : fakeColumnWidth;

--- a/client/src/common/QueryResultDataTable.tsx
+++ b/client/src/common/QueryResultDataTable.tsx
@@ -57,24 +57,25 @@ const bodyStyle: React.CSSProperties = {
 };
 
 const headerCellStyle: React.CSSProperties = {
-  lineHeight: '30px',
+  lineHeight: '22px',
   backgroundColor: '#f4f4f4',
   justifyContent: 'space-between',
   borderBottom: '1px solid #CCC',
   display: 'flex',
   fontWeight: 'bold',
-  paddingLeft: '.5rem',
-  paddingRight: '.5rem',
+  padding: 4,
 };
 
 const cellStyle: React.CSSProperties = {
-  lineHeight: '30px',
-  paddingLeft: '.5rem',
-  paddingRight: '.5rem',
+  lineHeight: '22px',
+  padding: 4,
   borderBottom: '1px solid #CCC',
   display: 'relative',
   overflowX: 'hidden',
   overflowY: 'hidden',
+  color: 'rgba(0, 0, 0, 0.65)',
+  fontFamily:
+    "'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace",
 };
 
 interface QueryResultDataTableProps {
@@ -93,9 +94,6 @@ interface QueryResultDataTableState {
   scrollbarWidth: number;
 }
 
-// NOTE: PureComponent's shallow compare works for this component
-// because the isRunning prop will toggle with each query execution
-// It would otherwise not rerender on change of prop.queryResult alone
 class QueryResultDataTable extends React.PureComponent<
   QueryResultDataTableProps,
   QueryResultDataTableState
@@ -113,12 +111,18 @@ class QueryResultDataTable extends React.PureComponent<
     this.setState({ scrollbarWidth: scrollbarWidth() });
   };
 
+  componentDidUpdate = () => {
+    // Make sure fake column is added in and sized right
+    this.recalc(0);
+  };
+
   static getDerivedStateFromProps(
     nextProps: QueryResultDataTableProps,
     prevState: QueryResultDataTableState
   ) {
     const { columns } = nextProps;
     const { columnWidths } = prevState;
+    // const { height, width } = this.state.dimensions;
 
     if (columns) {
       columns.forEach((column) => {
@@ -281,7 +285,8 @@ class QueryResultDataTable extends React.PureComponent<
           lines = valueLines;
         }
       });
-      return lines * 30;
+      // Line height is 22px, 8 is 4px padding top and bottom
+      return lines * 22 + 8;
     }
 
     return 30;
@@ -331,7 +336,7 @@ class QueryResultDataTable extends React.PureComponent<
                 columnCount={columnCount}
                 rowCount={1}
                 columnWidth={this.getColumnWidth}
-                rowHeight={this.getRowHeight}
+                rowHeight={() => 30}
                 height={30}
                 width={width - this.state.scrollbarWidth}
                 ref={this.headerGrid}

--- a/client/src/common/QueryResultDataTable.tsx
+++ b/client/src/common/QueryResultDataTable.tsx
@@ -111,23 +111,19 @@ class QueryResultDataTable extends React.PureComponent<
     this.setState({ scrollbarWidth: scrollbarWidth() });
   };
 
-  componentDidUpdate = () => {
-    // Make sure fake column is added in and sized right
-    this.recalc(0);
-  };
-
-  static getDerivedStateFromProps(
-    nextProps: QueryResultDataTableProps,
-    prevState: QueryResultDataTableState
-  ) {
-    const { columns } = nextProps;
-    const { columnWidths } = prevState;
+  componentDidUpdate = (prevProps: QueryResultDataTableProps) => {
+    const { columns } = this.props;
+    const { columnWidths } = this.state;
+    // TODO - take width into consideration for column sizes if few cols are used
     // const { height, width } = this.state.dimensions;
+
+    let newInitialColumn = false;
 
     if (columns) {
       columns.forEach((column) => {
         const { name, maxValueLength } = column;
         if (!columnWidths[name]) {
+          newInitialColumn = true;
           // (This length is number of characters -- it later gets assigned ~ 20px per char)
           let valueLength = maxValueLength || 8;
 
@@ -145,8 +141,14 @@ class QueryResultDataTable extends React.PureComponent<
         }
       });
     }
-    return { columnWidths };
-  }
+
+    if (newInitialColumn) {
+      this.setState({ columnWidths }, () => this.recalc(0));
+    } else {
+      // Make sure fake column is added in and sized right
+      this.recalc(0);
+    }
+  };
 
   // NOTE
   // An empty dummy column is added to the grid for visual purposes

--- a/client/src/common/QueryResultDataTable.tsx
+++ b/client/src/common/QueryResultDataTable.tsx
@@ -73,6 +73,8 @@ const cellStyle: React.CSSProperties = {
   paddingRight: '.5rem',
   borderBottom: '1px solid #CCC',
   display: 'relative',
+  overflowX: 'hidden',
+  overflowY: 'hidden',
 };
 
 interface QueryResultDataTableProps {
@@ -256,11 +258,7 @@ class QueryResultDataTable extends React.PureComponent<
     // If dataKey is present this is a real data cell to render
     if (column) {
       const value = rows?.[rowIndex]?.[columnIndex];
-      return (
-        <div style={finalStyle}>
-          <div className="truncate">{renderValue(value, column)}</div>
-        </div>
-      );
+      return <pre style={finalStyle}>{renderValue(value, column)}</pre>;
     }
 
     // If no dataKey this is a dummy cell.
@@ -272,9 +270,22 @@ class QueryResultDataTable extends React.PureComponent<
     );
   };
 
-  getRowHeight() {
+  getRowHeight = (index: number) => {
+    const { rows } = this.props;
+    if (rows) {
+      let lines = 1;
+      const row = rows[index] || [];
+      row.forEach((value) => {
+        const valueLines = `${value}`.split('\n').length;
+        if (valueLines > lines) {
+          lines = valueLines;
+        }
+      });
+      return lines * 30;
+    }
+
     return 30;
-  }
+  };
 
   // When a scroll occurs in the body grid,
   // synchronize the scroll position of the header grid

--- a/client/src/queryHistory/QueryHistoryContent.tsx
+++ b/client/src/queryHistory/QueryHistoryContent.tsx
@@ -3,21 +3,22 @@ import Button from '../common/Button';
 import ErrorBlock from '../common/ErrorBlock';
 import QueryResultDataTable from '../common/QueryResultDataTable';
 import QueryResultRunning from '../common/QueryResultRunning';
+import { StatementColumn } from '../types';
 import { api } from '../utilities/api';
 import QueryHistoryFilterItem, { Filter } from './QueryHistoryFilterItem';
 
-const COLUMNS = [
-  { name: 'userEmail', datatype: 'string' },
-  { name: 'connectionName', datatype: 'string' },
-  { name: 'startTime', datatype: 'datetime' },
-  { name: 'stopTime', datatype: 'datetime' },
-  { name: 'durationMs', datatype: 'number' },
-  { name: 'queryId', datatype: 'string' },
-  { name: 'queryName', datatype: 'string' },
-  { name: 'queryText', datatype: 'string' },
-  { name: 'incomplete', datatype: 'boolean' },
-  { name: 'rowCount', datatype: 'number' },
-  { name: 'createdAt', datatype: 'datetime' },
+const COLUMNS: StatementColumn[] = [
+  { name: 'userEmail', datatype: 'string', maxLineLength: 20 },
+  { name: 'connectionName', datatype: 'string', maxLineLength: 20 },
+  { name: 'startTime', datatype: 'datetime', maxLineLength: 23 },
+  { name: 'stopTime', datatype: 'datetime', maxLineLength: 23 },
+  { name: 'durationMs', datatype: 'number', maxLineLength: 10 },
+  { name: 'queryId', datatype: 'string', maxLineLength: 36 },
+  { name: 'queryName', datatype: 'string', maxLineLength: 30 },
+  { name: 'queryText', datatype: 'string', maxLineLength: 50 },
+  { name: 'incomplete', datatype: 'boolean', maxLineLength: 4 },
+  { name: 'rowCount', datatype: 'number', maxLineLength: 8 },
+  { name: 'createdAt', datatype: 'datetime', maxLineLength: 23 },
 ];
 
 function QueryHistoryContent() {

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -15,10 +15,25 @@ export interface Connection {
 export type StatementResults = Array<Array<any>>;
 
 export interface StatementColumn {
-  datatype: string;
+  datatype:
+    | 'date'
+    | 'datetime'
+    | 'object'
+    | 'number'
+    | 'boolean'
+    | 'string'
+    | null;
   max?: number | string | Date | boolean;
   min?: number | string | Date | boolean;
+  /**
+   * Number of characters longest value ignoring new lines
+   */
   maxValueLength?: number;
+  /**
+   * Number of characters in longest line of data for this column.
+   * Objects are JSON.stringify(value, null, 2)
+   */
+  maxLineLength?: number;
   name: string;
 }
 

--- a/server/test/lib/get-columns.js
+++ b/server/test/lib/get-columns.js
@@ -65,41 +65,94 @@ describe('lib/get-columns.js', function () {
       cMap[c.name] = c;
     });
 
-    assert.equal(cMap.alwaysNull.datatype, null, 'null');
+    assert.deepStrictEqual(cMap.alwaysNull, {
+      name: 'alwaysNull',
+      datatype: null,
+      max: null,
+      min: null,
+      maxLineLength: 0,
+      maxValueLength: 0,
+    });
 
-    assert.equal(cMap.accountNumber.datatype, 'string', 'accountNumber');
-    assert.equal(
-      cMap.accountNumber.maxValueLength,
-      6,
-      'accountNumber.maxValueLength'
-    );
+    assert.deepStrictEqual(cMap.accountNumber, {
+      name: 'accountNumber',
+      datatype: 'string',
+      max: null,
+      min: null,
+      maxLineLength: 6,
+      maxValueLength: 6,
+    });
 
-    assert.equal(cMap.decimalString.datatype, 'number', 'decimalString');
-    assert.equal(cMap.decimalString.max, 0.999, 'decimalString.max');
-    assert.equal(cMap.decimalString.min, 0.111, 'decimalString.min');
+    assert.deepStrictEqual(cMap.decimalString, {
+      name: 'decimalString',
+      datatype: 'number',
+      max: 0.999,
+      min: 0.111,
+      maxLineLength: 0,
+      maxValueLength: 0,
+    });
 
-    assert.equal(cMap.number.datatype, 'number', 'number.datatype');
-    assert.equal(cMap.number.max, 30, 'number.max');
-    assert.equal(cMap.number.min, 0, 'number.min');
+    assert.deepStrictEqual(cMap.number, {
+      name: 'number',
+      datatype: 'number',
+      max: 30,
+      min: 0,
+      maxLineLength: 0,
+      maxValueLength: 0,
+    });
 
-    assert.equal(cMap.string.datatype, 'string', 'string.datatype');
-    assert.equal(cMap.string.maxValueLength, 7, 'string.maxValueLength');
-    assert.equal(cMap.string.maxLineLength, 7, 'string.maxLineLength');
+    assert.deepStrictEqual(cMap.string, {
+      name: 'string',
+      datatype: 'string',
+      max: null,
+      min: null,
+      maxLineLength: 7,
+      maxValueLength: 7,
+    });
 
-    assert.equal(cMap.datetime.datatype, 'datetime', 'datetime.datatype');
-    assert.equal(cMap.datetime.max.getTime(), d2.getTime(), 'datetime.max');
-    assert.equal(cMap.datetime.min.getTime(), d1.getTime(), 'datetime.min');
+    assert.deepStrictEqual(cMap.datetime, {
+      name: 'datetime',
+      datatype: 'datetime',
+      max: d2,
+      min: d1,
+      maxLineLength: 23,
+      maxValueLength: 23,
+    });
 
-    assert.equal(cMap.numberString.datatype, 'number', 'numberString.datatype');
-    assert.equal(cMap.numberString.max, 100, 'numberString.max');
-    assert.equal(cMap.numberString.min, 0, 'numberString.min');
+    assert.deepStrictEqual(cMap.numberString, {
+      name: 'numberString',
+      datatype: 'number',
+      max: 100,
+      min: 0,
+      maxLineLength: 0,
+      maxValueLength: 0,
+    });
 
-    assert.equal(cMap.date.datatype, 'date', 'date.datatype');
+    assert.deepStrictEqual(cMap.date, {
+      name: 'date',
+      datatype: 'date',
+      max: noTime,
+      min: noTime,
+      maxLineLength: 10,
+      maxValueLength: 10,
+    });
 
-    assert.equal(cMap.bool.datatype, 'boolean', 'bool.datatype');
+    assert.deepStrictEqual(cMap.bool, {
+      name: 'bool',
+      datatype: 'boolean',
+      max: null,
+      min: null,
+      maxLineLength: 4,
+      maxValueLength: 4,
+    });
 
-    assert.equal(cMap.obj.datatype, 'object', 'obj.datatype');
-    assert.equal(cMap.obj.maxValueLength, 30, 'obj.maxValueLength');
-    assert.equal(cMap.obj.maxLineLength, 13, 'obj.maxLineLength');
+    assert.deepStrictEqual(cMap.obj, {
+      name: 'obj',
+      datatype: 'object',
+      max: null,
+      min: null,
+      maxLineLength: 13,
+      maxValueLength: 30,
+    });
   });
 });

--- a/server/test/lib/get-columns.js
+++ b/server/test/lib/get-columns.js
@@ -18,6 +18,8 @@ describe('lib/get-columns.js', function () {
         datetime: null,
         numberString: null,
         date: noTime,
+        bool: false,
+        obj: {},
       },
       {
         alwaysNull: null,
@@ -28,6 +30,8 @@ describe('lib/get-columns.js', function () {
         datetime: d2,
         numberString: 100,
         date: null,
+        bool: true,
+        obj: { a: 'foo', b: 'bar' },
       },
       {
         alwaysNull: null,
@@ -38,6 +42,8 @@ describe('lib/get-columns.js', function () {
         datetime: d1,
         numberString: 0,
         date: noTime,
+        bool: true,
+        obj: null,
       },
       {
         alwaysNull: null,
@@ -48,6 +54,8 @@ describe('lib/get-columns.js', function () {
         datetime: null,
         numberString: null,
         date: noTime,
+        bool: true,
+        obj: { a: 'foo', b: 'bar' },
       },
     ];
 
@@ -76,6 +84,7 @@ describe('lib/get-columns.js', function () {
 
     assert.equal(cMap.string.datatype, 'string', 'string.datatype');
     assert.equal(cMap.string.maxValueLength, 7, 'string.maxValueLength');
+    assert.equal(cMap.string.maxLineLength, 7, 'string.maxLineLength');
 
     assert.equal(cMap.datetime.datatype, 'datetime', 'datetime.datatype');
     assert.equal(cMap.datetime.max.getTime(), d2.getTime(), 'datetime.max');
@@ -86,5 +95,11 @@ describe('lib/get-columns.js', function () {
     assert.equal(cMap.numberString.min, 0, 'numberString.min');
 
     assert.equal(cMap.date.datatype, 'date', 'date.datatype');
+
+    assert.equal(cMap.bool.datatype, 'boolean', 'bool.datatype');
+
+    assert.equal(cMap.obj.datatype, 'object', 'obj.datatype');
+    assert.equal(cMap.obj.maxValueLength, 30, 'obj.maxValueLength');
+    assert.equal(cMap.obj.maxLineLength, 13, 'obj.maxLineLength');
   });
 });


### PR DESCRIPTION
Misc enhancements with a goal of showing multi-line content in query results. 

- For text values, number of lines of text are counted for each column. Row height is sized for column with most lines.
- For JSON and other objects, values are JSON pretty-printed for multi-line rendering
- Changes grid font family to monospace
- Adds shadow to indicate text overflow
- If single column is returned, column is adjusted to use full width of result area

closes #902 