### PR TITLE
Fix LDAP auth for profiles without mail attribute

### DIFF
--- a/server/models/users.js
+++ b/server/models/users.js
@@ -37,6 +37,10 @@ class Users {
     return this.findOneById(id);
   }
 
+  /**
+   * For LDAP auth, account login may be used instead of proper email address
+   * @param {string} email
+   */
   async findOneByEmail(email) {
     const user = await this.sequelizeDb.Users.findOne({
       where: { email: email.toLowerCase() },

--- a/server/sequelize-db/users.js
+++ b/server/sequelize-db/users.js
@@ -9,6 +9,8 @@ module.exports = function (sequelize) {
         primaryKey: true,
         defaultValue: DataTypes.UUIDV4,
       },
+      // For LDAP auth, this may contain account login if profile.mail does not exist
+      // This field serves purpose of lower-cased external id
       email: {
         type: DataTypes.STRING,
         allowNull: false,


### PR DESCRIPTION
Fixes LDAP auth for case where profile does not have `mail` attribute. In this case the account login will be used in place of email, and stored on `users.email`.  Addresses part of #898.

I have mixed feelings about this as it is kind of abusing the `users` table data model a bit, but it keeps auth flows simple and allows this LDAP case to work without impacting other auth strategies and requiring significant work in the UI/data model/API, and so on.

Two potential changes in the future to address that:
- email could be renamed or officially repurposed as an "external id" field. 
- An additional external id field can be added to `users` table, unique constraint removed from `users.email`, and auth flows, UI, APIs updated to accommodate the new field addition.