### PR TITLE
Store user ldap account name in own column (ldap_id)

### DIFF
--- a/client/src/app-header/AppHeaderUser.tsx
+++ b/client/src/app-header/AppHeaderUser.tsx
@@ -10,7 +10,7 @@ function UserButton() {
   return (
     <div className={styles.style}>
       {' '}
-      {currentUser?.name || currentUser.email}
+      {currentUser?.name || currentUser.email || currentUser.ldapId}
     </div>
   );
 }

--- a/client/src/connectionAccesses/ConnectionAccessForm.tsx
+++ b/client/src/connectionAccesses/ConnectionAccessForm.tsx
@@ -14,6 +14,13 @@ type Edits = {
   duration?: string;
 };
 
+interface UserSummary {
+  id: string;
+  name?: string;
+  email?: string;
+  ldapId?: string;
+}
+
 interface Props {
   onConnectionAccessSaved: (connectionAccess: ConnectionAccess) => void;
 }
@@ -31,12 +38,24 @@ function ConnectionAccessForm({ onConnectionAccessSaved }: Props) {
   ].concat(apiConnections || []);
 
   let { data: apiUsers } = api.useUsers();
-  const users = [
+
+  const users: UserSummary[] = [
     {
       id: '__EVERYONE__',
       email: 'Everyone',
     },
-  ].concat(apiUsers || []);
+  ];
+
+  if (apiUsers) {
+    apiUsers.forEach((user) => {
+      users.push({
+        id: user.id,
+        email: user.email,
+        name: user.name,
+        ldapId: user.ldapId,
+      });
+    });
+  }
 
   const setConnectionAccessValue = (key: keyof Edits, value: string) => {
     setConnectionAccessEdits((prev) => ({ ...prev, [key]: value }));
@@ -95,7 +114,7 @@ function ConnectionAccessForm({ onConnectionAccessSaved }: Props) {
     sortBy(users, ['email']).forEach((user) =>
       userSelectOptions.push(
         <option key={user.id} value={user.id}>
-          {user.email}
+          {user.email || user.name || user.ldapId}
         </option>
       )
     );

--- a/client/src/queryEditor/ACLInput.tsx
+++ b/client/src/queryEditor/ACLInput.tsx
@@ -35,7 +35,10 @@ function ACLInput({ acl, onChange, disabled }: Props) {
     users
       .filter((user) => user.id !== queryAuthorId)
       .map((user) => {
-        return { value: user.id, label: user.name || user.email };
+        return {
+          value: user.id,
+          label: user.name || user.email || user.ldapId || '',
+        };
       })
   );
 

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -123,9 +123,10 @@ export interface AppInfo {
   // brief user info if user is logged in
   currentUser?: {
     id: string;
-    email: string;
+    email?: string;
     role: string;
     name?: string;
+    ldapId?: string;
   };
   version: string;
 }
@@ -203,9 +204,10 @@ export interface QueryDetail {
 
 export interface User {
   id: string;
-  email: string;
+  email?: string;
   name: string;
   role: string;
+  ldapId?: string;
   syncAuthRole?: boolean | null;
   disabled: boolean;
   signupAt: string | Date;

--- a/server/migrations/06-00100-user-ldap-id.js
+++ b/server/migrations/06-00100-user-ldap-id.js
@@ -1,0 +1,60 @@
+const Sequelize = require('sequelize');
+const migrationUtils = require('../lib/migration-utils');
+
+/**
+ * @param {import('sequelize').QueryInterface} queryInterface
+ * @param {import('../lib/config')} config
+ * @param {import('../lib/logger')} appLog
+ * @param {object} sequelizeDb - sequelize instance
+ */
+// eslint-disable-next-line no-unused-vars
+async function up(queryInterface, config, appLog, sequelizeDb) {
+  try {
+    // remove unique not-null constraint for email
+    await queryInterface.changeColumn('users', 'email', {
+      type: Sequelize.STRING,
+      allowNull: true,
+      unique: false,
+    });
+  } catch (error) {
+    // ignore error. constraint may not exist depending on backend database
+  }
+
+  await migrationUtils.addOrReplaceIndex(
+    queryInterface,
+    'users',
+    'users_email',
+    ['email'],
+    {
+      unique: true,
+      where: {
+        email: {
+          [Sequelize.Op.ne]: null,
+        },
+      },
+    }
+  );
+
+  await queryInterface.addColumn('users', 'ldap_id', {
+    type: Sequelize.STRING,
+  });
+
+  await migrationUtils.addOrReplaceIndex(
+    queryInterface,
+    'users',
+    'users_ldap_id',
+    ['ldap_id'],
+    {
+      unique: true,
+      where: {
+        ldap_id: {
+          [Sequelize.Op.ne]: null,
+        },
+      },
+    }
+  );
+}
+
+module.exports = {
+  up,
+};

--- a/server/models/users.js
+++ b/server/models/users.js
@@ -71,6 +71,7 @@ class Users {
         'id',
         'name',
         'email',
+        'ldapId',
         'role',
         'disabled',
         'signupAt',

--- a/server/models/users.js
+++ b/server/models/users.js
@@ -44,12 +44,25 @@ class Users {
   }
 
   /**
-   * For LDAP auth, account login may be used instead of proper email address
    * @param {string} email
    */
   async findOneByEmail(email) {
     const user = await this.sequelizeDb.Users.findOne({
       where: { email: email.toLowerCase() },
+    });
+    if (user) {
+      let final = user.toJSON();
+      final.data = ensureJson(final.data);
+      return final;
+    }
+  }
+
+  /**
+   * @param {string} ldapId
+   */
+  async findOneByLdapId(ldapId) {
+    const user = await this.sequelizeDb.Users.findOne({
+      where: { ldapId: ldapId.toLowerCase() },
     });
     if (user) {
       let final = user.toJSON();

--- a/server/models/users.js
+++ b/server/models/users.js
@@ -19,6 +19,9 @@ class Users {
     if (rest.email) {
       rest.email = rest.email.toLowerCase();
     }
+    if (rest.ldapId) {
+      rest.ldapId = rest.ldapId.toLowerCase();
+    }
 
     const newUser = await this.sequelizeDb.Users.create(rest);
     return this.findOneById(newUser.id);
@@ -31,6 +34,9 @@ class Users {
     }
     if (rest.email) {
       rest.email = rest.email.toLowerCase();
+    }
+    if (rest.ldapId) {
+      rest.ldapId = rest.ldapId.toLowerCase();
     }
 
     await this.sequelizeDb.Users.update(rest, { where: { id } });

--- a/server/routes/app.js
+++ b/server/routes/app.js
@@ -16,6 +16,7 @@ async function getApp(req, res) {
           email: req.user.email,
           role: req.user.role,
           name: req.user.name,
+          ldapId: req.user.ldapId,
         }
       : undefined;
 

--- a/server/sequelize-db/users.js
+++ b/server/sequelize-db/users.js
@@ -9,11 +9,18 @@ module.exports = function (sequelize) {
         primaryKey: true,
         defaultValue: DataTypes.UUIDV4,
       },
-      // For LDAP auth, this may contain account login if profile.mail does not exist
-      // This field serves purpose of lower-cased external id
       email: {
         type: DataTypes.STRING,
-        allowNull: false,
+        allowNull: true,
+        validate: {
+          isLowercase: true,
+        },
+      },
+      // User account ID for LDAP authentication
+      // Currently this is used as a fallback when ldap profile.mail is not available
+      ldapId: {
+        type: DataTypes.STRING,
+        allowNull: true,
         validate: {
           isLowercase: true,
         },

--- a/server/test/api/users.js
+++ b/server/test/api/users.js
@@ -7,6 +7,7 @@ function isNonAdminUserPayload(user) {
     'id',
     'name',
     'email',
+    'ldapId',
     'role',
     'createdAt',
     'updatedAt',
@@ -189,5 +190,21 @@ describe('api/users', function () {
   it('Returns expected list', async function () {
     const body = await utils.get('admin', '/api/users');
     assert.equal(body.length, 3, '3 length');
+  });
+
+  it('Creates user with ldapId', async function () {
+    const user = await utils.post('admin', '/api/users', {
+      email: 'userldap@test.com',
+      ldapId: 'USERLDAP',
+      name: 'user1',
+      role: 'editor',
+      data: {
+        create: true,
+      },
+    });
+
+    assert(user.id, 'has id');
+    assert.equal(user.email, 'userldap@test.com');
+    assert.equal(user.ldapId, 'userldap');
   });
 });

--- a/server/test/auth/ldap.js
+++ b/server/test/auth/ldap.js
@@ -363,6 +363,8 @@ describe('auth/ldap', function () {
 
     const agent = request.agent(utils.app);
 
+    // Initial Sign in will capture ldapId, so this needs to be done twice
+    // Second time it should not change
     await agent
       .post('/api/signin')
       .send({
@@ -371,13 +373,25 @@ describe('auth/ldap', function () {
       })
       .expect(200);
 
-    const afterSignIn = await utils.models.users.findOneByEmail(
+    const afterSignIn1 = await utils.models.users.findOneByEmail(
+      'hermes@planetexpress.com'
+    );
+
+    await agent
+      .post('/api/signin')
+      .send({
+        password: 'hermes',
+        email: 'hermes',
+      })
+      .expect(200);
+
+    const afterSignIn2 = await utils.models.users.findOneByEmail(
       'hermes@planetexpress.com'
     );
 
     assert.equal(
-      initialUser.updatedAt.valueOf(),
-      afterSignIn.updatedAt.valueOf()
+      afterSignIn1.updatedAt.valueOf(),
+      afterSignIn2.updatedAt.valueOf()
     );
   });
 });


### PR DESCRIPTION
It is possible for some LDAP setups to not provide or populate profile email address. 

As a fallback, account username was stored in SQLPad's `users.email` column, but this could get confusing and may not be ideal long term.

This PR implements an alternative approach where the LDAP user account is stored in SQLPad's `users.ldap_id` column. `users.email` is made a nullable field.