### PR TITLE
Use cancelled status for statements following error

### DIFF
--- a/server/models/statements.js
+++ b/server/models/statements.js
@@ -138,7 +138,15 @@ class Statements {
       error,
     };
     await this.sequelizeDb.Statements.update(update, { where: { id } });
+
     return this.findOneById(id);
+  }
+
+  async updateErrorQueuedToCancelled(batchId) {
+    await this.sequelizeDb.Statements.update(
+      { status: 'cancelled' },
+      { where: { batchId, status: 'queued' } }
+    );
   }
 
   async updateFinished(id, queryResult, stopTime, durationMs) {

--- a/server/sequelize-db/batches.js
+++ b/server/sequelize-db/batches.js
@@ -28,6 +28,7 @@ module.exports = function (sequelize) {
         validate: {
           // Potentially add 'cancelled'?
           // We have no way of canceling current statement but future could be
+          // If a batch errors, any statements following error will be "cancelled" status
           isIn: [['started', 'finished', 'error']],
         },
         defaultValue: 'started',

--- a/server/sequelize-db/statements.js
+++ b/server/sequelize-db/statements.js
@@ -21,11 +21,13 @@ module.exports = function (sequelize) {
         type: Sequelize.TEXT,
         allowNull: false,
       },
+      // If a batch errors, any statements following error will be "cancelled" status
+      // At this time statements/batches cannot be cancelled otherwise
       status: {
         type: Sequelize.STRING,
         allowNull: false,
         validate: {
-          isIn: [['queued', 'started', 'finished', 'error']],
+          isIn: [['queued', 'started', 'finished', 'error', 'cancelled']],
         },
         defaultValue: 'queued',
       },

--- a/server/test/api/batches.js
+++ b/server/test/api/batches.js
@@ -199,7 +199,7 @@ describe('api/batches', function () {
     assert.deepEqual(b.statements[0].error, {
       title: 'SQLITE_ERROR: incomplete input',
     });
-    assert.equal(b.statements[1].status, 'queued');
+    assert.equal(b.statements[1].status, 'cancelled');
     assert.equal(b.statements[1].rowCount, null, 'no rowCount');
     assert.equal(b.statements[1].resultsPath, null, 'no resultpath');
     assert.equal(b.statements[1].startTime, null, 'no startTime');


### PR DESCRIPTION
Updates batch/statement logic for statements that follow an errored statement. Instead of `queued`, statements following an `error`  statement will be updated to `cancelled`.