### PR TITLE
Return 404 for unfinished statement results API

### DIFF
--- a/server/routes/statements.js
+++ b/server/routes/statements.js
@@ -51,6 +51,10 @@ async function getStatementResults(req, res) {
     return res.utils.notFound();
   }
 
+  if (statement.status !== 'finished') {
+    return res.utils.notFound();
+  }
+
   // Get batch to ensure it was created by User.
   // This is not the most efficient since it gets statements again
   // Need to maybe rethink these models functions

--- a/server/test/api/batches.js
+++ b/server/test/api/batches.js
@@ -199,11 +199,24 @@ describe('api/batches', function () {
     assert.deepEqual(b.statements[0].error, {
       title: 'SQLITE_ERROR: incomplete input',
     });
+
+    await utils.get(
+      'admin',
+      `/api/statements/${b.statements[0].id}/results`,
+      404
+    );
+
     assert.equal(b.statements[1].status, 'cancelled');
     assert.equal(b.statements[1].rowCount, null, 'no rowCount');
     assert.equal(b.statements[1].resultsPath, null, 'no resultpath');
     assert.equal(b.statements[1].startTime, null, 'no startTime');
     assert.equal(b.statements[1].stopTime, null, 'no stopTime');
+
+    await utils.get(
+      'admin',
+      `/api/statements/${b.statements[1].id}/results`,
+      404
+    );
   });
 
   it('statement without rows does not create file', async function () {


### PR DESCRIPTION
Prior implementation returned empty results, which is misleading since the query isn't finished. Going with 404, but a 400 might also be fitting since getting results for a statement that has not finished could be considered "incorrect" or client error?