### PR TITLE
Add status to query history

### DIFF
--- a/client/src/queryHistory/QueryHistoryContent.tsx
+++ b/client/src/queryHistory/QueryHistoryContent.tsx
@@ -10,6 +10,7 @@ import QueryHistoryFilterItem, { Filter } from './QueryHistoryFilterItem';
 const COLUMNS: StatementColumn[] = [
   { name: 'userEmail', datatype: 'string', maxLineLength: 20 },
   { name: 'connectionName', datatype: 'string', maxLineLength: 20 },
+  { name: 'status', datatype: 'string', maxLineLength: 20 },
   { name: 'startTime', datatype: 'datetime', maxLineLength: 23 },
   { name: 'stopTime', datatype: 'datetime', maxLineLength: 23 },
   { name: 'durationMs', datatype: 'number', maxLineLength: 10 },

--- a/client/src/queryHistory/QueryHistoryFilterItem.tsx
+++ b/client/src/queryHistory/QueryHistoryFilterItem.tsx
@@ -49,6 +49,10 @@ const QueryHistoryFilterItem = ({
       label: 'connectionName',
       operators: [operators.contains],
     },
+    status: {
+      label: 'status',
+      operators: [operators.contains],
+    },
     startTime: {
       label: 'startTime',
       operators: [operators.before, operators.after],

--- a/server/lib/url-filter-to-db-filter.js
+++ b/server/lib/url-filter-to-db-filter.js
@@ -36,6 +36,7 @@ module.exports = function urlFilterToDbFilter(urlFilter) {
                 case 'eq':
                 case 'ne':
                   dbOperator = Op[operator];
+                  // TODO FIXME - not all equals values will be int (query history status for example)
                   dbValue = parseInt(value);
                   break;
                 case 'before':

--- a/server/sequelize-db/query-history.js
+++ b/server/sequelize-db/query-history.js
@@ -20,6 +20,9 @@ module.exports = function (sequelize) {
       userEmail: {
         type: DataTypes.STRING,
       },
+      status: {
+        type: DataTypes.TEXT,
+      },
       startTime: {
         type: DataTypes.DATE,
       },

--- a/server/test/api/query-history.js
+++ b/server/test/api/query-history.js
@@ -135,6 +135,7 @@ describe('api/query-history', function () {
       'connectionName',
       'userId',
       'userEmail',
+      'status',
       'startTime',
       'stopTime',
       'durationMs',


### PR DESCRIPTION
Adds status to query history. Status will show "finished" or "error" status. Actual error message is not shown with this PR.