### PR TITLE
Use wrapIntegers to prevent int64 truncation

### DIFF
--- a/server/drivers/bigquery/index.js
+++ b/server/drivers/bigquery/index.js
@@ -100,7 +100,12 @@ function runQuery(queryString, connection = {}) {
     .createQueryJob(query)
     .then(([job]) => {
       // Wait for the query to finish.
-      const options = { timeoutMs: timeoutSeconds * 1000 };
+      const options = {
+        timeoutMs: timeoutSeconds * 1000,
+        wrapIntegers: {
+          integerTypeCastFunction: (val) => val.toString(),
+        },
+      };
       if (isMaxRowsSpecified) {
         options.maxResults = connection.maxRows + 1;
       }


### PR DESCRIPTION
This translates the raw int64 returned over the API and represents
it as a string rather than as a JavaScript integer to prevent
truncating to 52 bits prior to rendering.

Signed-off-by: Byron Ruth <b@devel.io>