### PR TITLE
Github action optimizations

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm install
-      - run: npm install --prefix client
-      - run: npm install --prefix server
+      - run: npm ci
+      - run: npm ci --prefix client
+      - run: npm ci --prefix server
       - run: npm run lint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: SQLPad release
 on:
   push:
     tags:
-      - "*"
+      - '*'
 
 jobs:
   build:
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build
-        uses: docker://node:13-slim
+        uses: docker://node:14-slim
         with:
           entrypoint: bash
           args: .github/workflows/build.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 13.x, 14.x, 15.x]
+        node-version: [12.x, 14.x, 15.x]
 
     steps:
       - uses: actions/checkout@v2
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false # if one job fails, others will not be aborted
       matrix:
         backendtype: ['', 'mssql', 'mysql', 'mariadb', 'postgres']
-        node-version: [12.x, 13.x, 14.x, 15.x]
+        node-version: [12.x, 14.x, 15.x]
 
     steps:
       - uses: actions/checkout@v2
@@ -82,7 +82,6 @@ jobs:
             docker ps
             sleep 0.5
           done
-
 
       - name: Test
         run: npm run test${{ matrix.backendtype }} --prefix server

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,7 @@ jobs:
   test:
     needs: build
     runs-on: ubuntu-20.04
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false # if one job fails, others will not be aborted

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -25,7 +25,7 @@ services:
         ]
       interval: 5s
       timeout: 3s
-      retries: 40
+      retries: 10
 
   mssql:
     image: 'mcr.microsoft.com/mssql/server:2019-CU8-ubuntu-16.04'
@@ -52,8 +52,8 @@ services:
           'SELECT 1',
         ]
       interval: 5s
-      timeout: 2s
-      retries: 40
+      timeout: 3s
+      retries: 10
 
   postgres:
     image: postgres:9.6-alpine
@@ -67,7 +67,7 @@ services:
       test: ['CMD', 'pg_isready']
       interval: 5s
       timeout: 2s
-      retries: 40
+      retries: 10
 
   mariadb:
     image: mariadb:10.3
@@ -82,7 +82,7 @@ services:
       test: ['CMD', 'mysqladmin', 'status', '-uroot', '-ppassword']
       interval: 5s
       timeout: 2s
-      retries: 40
+      retries: 10
 
   mysql:
     image: mysql:8
@@ -97,4 +97,4 @@ services:
       test: ['CMD', 'mysql', '-uuser', '-ppassword', '-e', 'select 1']
       interval: 5s
       timeout: 2s
-      retries: 40
+      retries: 10

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -30,6 +30,7 @@ services:
   mssql:
     image: 'mcr.microsoft.com/mssql/server:2019-CU8-ubuntu-16.04'
     hostname: 'mssql'
+    restart: unless-stopped
     ports:
       - 1433:1433
     environment:
@@ -50,8 +51,8 @@ services:
           '-Q',
           'SELECT 1',
         ]
-      interval: 10s
-      timeout: 10s
+      interval: 5s
+      timeout: 2s
       retries: 40
 
   postgres:

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -14,18 +14,21 @@ services:
         [
           'CMD',
           'ldapsearch',
-          '-H', 'ldap://127.0.0.1:10389',
-          '-D', 'cn=admin,dc=planetexpress,dc=com',
-          '-w', 'GoodNewsEveryone',
-          '-b', 'cn=admin,dc=planetexpress,dc=com'
+          '-H',
+          'ldap://127.0.0.1:10389',
+          '-D',
+          'cn=admin,dc=planetexpress,dc=com',
+          '-w',
+          'GoodNewsEveryone',
+          '-b',
+          'cn=admin,dc=planetexpress,dc=com',
         ]
-      interval: 3s
+      interval: 5s
       timeout: 3s
-      retries: 10
-
+      retries: 40
 
   mssql:
-    image: 'mcr.microsoft.com/mssql/server:2017-latest'
+    image: 'mcr.microsoft.com/mssql/server:2019-CU8-ubuntu-16.04'
     hostname: 'mssql'
     ports:
       - 1433:1433
@@ -47,9 +50,9 @@ services:
           '-Q',
           'SELECT 1',
         ]
-      interval: 3s
+      interval: 5s
       timeout: 3s
-      retries: 10
+      retries: 40
 
   postgres:
     image: postgres:9.6-alpine
@@ -63,7 +66,7 @@ services:
       test: ['CMD', 'pg_isready']
       interval: 5s
       timeout: 2s
-      retries: 10
+      retries: 40
 
   mariadb:
     image: mariadb:10.3
@@ -78,7 +81,7 @@ services:
       test: ['CMD', 'mysqladmin', 'status', '-uroot', '-ppassword']
       interval: 5s
       timeout: 2s
-      retries: 10
+      retries: 40
 
   mysql:
     image: mysql:8
@@ -93,4 +96,4 @@ services:
       test: ['CMD', 'mysql', '-uuser', '-ppassword', '-e', 'select 1']
       interval: 5s
       timeout: 2s
-      retries: 10
+      retries: 40

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -50,8 +50,8 @@ services:
           '-Q',
           'SELECT 1',
         ]
-      interval: 5s
-      timeout: 3s
+      interval: 10s
+      timeout: 10s
       retries: 40
 
   postgres:


### PR DESCRIPTION
FYI @eladeyal-intel tweaking GitHub action things a bit

- Removing Node 13.x from matrix. Odd numbered releases are short-lived, and I think form the basis for what comes of next even numbered release, which are LTS versions of node. So I figure to cut down on test running we can drop 13, but keep 15 since it is the current version https://nodejs.org/en/about/releases/ 
- Uses npm ci for lint install (should be slightly faster and uses lock file for a more reproducible build)
- Uses node 14 for artifact build
- Uses latest SQL Server 2019 image, and increases health check retries. Hoping this cuts down on number of failed tests where action is waiting for server to start up.