### PR TITLE
remove custom health-check command

### DIFF
--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -12,19 +12,6 @@ services:
     ports:
       - 10389:10389
     healthcheck:
-      test:
-        [
-          'CMD',
-          'ldapsearch',
-          '-H',
-          'ldap://127.0.0.1:10389',
-          '-D',
-          'cn=admin,dc=planetexpress,dc=com',
-          '-w',
-          'GoodNewsEveryone',
-          '-b',
-          'cn=admin,dc=planetexpress,dc=com',
-        ]
       interval: 5s
       timeout: 2s
       retries: 10


### PR DESCRIPTION
no longer needed because it's now part of the image

https://github.com/rroemhild/docker-test-openldap/pull/26#issuecomment-775067792