### PR TITLE
Warn for unknown environment variable

### DIFF
--- a/server/lib/config/index.js
+++ b/server/lib/config/index.js
@@ -128,14 +128,8 @@ class Config {
     // Any key that starts with SQLPAD_ that isn't known should raise a message.
     // Exceptions:
     // - SQLPAD_CONNECTIONS__ variables as they are dynamic and depend on database defined
-    // - SQLPAD_SERVICE_ variables as they may be used in a kubernetes environment
     Object.keys(this.env).forEach((key) => {
-      if (
-        key.startsWith('SQLPAD_') &&
-        !isConnectionEnv(key) &&
-        !key.startsWith('SQLPAD_SERVICE_') &&
-        !key.startsWith('SQLPAD_PORT_')
-      ) {
+      if (key.startsWith('SQLPAD_') && !isConnectionEnv(key)) {
         const foundDefinition = configItems.find((item) => item.envVar === key);
         if (!foundDefinition) {
           // If key wasn't found, check known removed variables

--- a/server/lib/config/index.js
+++ b/server/lib/config/index.js
@@ -12,6 +12,42 @@ const {
 } = require('./config-utils');
 const drivers = require('../../drivers');
 
+const REMOVED_ENVS = [
+  'CERT_PASSPHRASE',
+  'CERT_PATH',
+  'DISABLE_AUTH',
+  'DISABLE_USERPASS_AUTH',
+  'ENABLE_LDAP_AUTH',
+  'GOOGLE_CLIENT_ID',
+  'GOOGLE_CLIENT_SECRET',
+  'KEY_PATH',
+  'LDAP_BASE_DN',
+  'LDAP_PASSWORD',
+  'LDAP_URL',
+  'LDAP_USERNAME',
+  'SAML_AUTH_CONTEXT',
+  'SAML_CALLBACK_URL',
+  'SAML_CERT',
+  'SAML_ENTRY_POINT',
+  'SAML_ISSUER',
+  'SAML_LINK_HTML',
+  'SERVICE_TOKEN_SECRET',
+  'SQLPAD_DEBUG',
+  'SQLPAD_DISABLE_AUTH_DEFAULT_ROLE',
+  'SQLPAD_HTTPS_PORT',
+  'SQLPAD_LDAP_BASE_DN',
+  'SQLPAD_LDAP_USERNAME',
+  'SQLPAD_SLACK_WEBHOOK',
+  'SQLPAD_SMTP_FROM',
+  'SQLPAD_SMTP_HOST',
+  'SQLPAD_SMTP_PASSWORD',
+  'SQLPAD_SMTP_PORT',
+  'SQLPAD_SMTP_SECURE',
+  'SQLPAD_SMTP_USER',
+  'SQLPAD_TABLE_CHART_LINKS_REQUIRE_AUTH',
+  'WHITELISTED_DOMAINS',
+];
+
 class Config {
   constructor(argv, env) {
     this.argv = argv;
@@ -97,13 +133,24 @@ class Config {
       if (
         key.startsWith('SQLPAD_') &&
         !isConnectionEnv(key) &&
-        !key.startsWith('SQLPAD_SERVICE_')
+        !key.startsWith('SQLPAD_SERVICE_') &&
+        !key.startsWith('SQLPAD_PORT_')
       ) {
         const foundDefinition = configItems.find((item) => item.envVar === key);
         if (!foundDefinition) {
-          errors.push(
-            `CONFIG NOT RECOGNIZED: Environment variable "${key}" no longer supported.`
-          );
+          // If key wasn't found, check known removed variables
+          // If previously used, raise error, otherwise log warning
+          // Environments like k8s may use SQLPAD_* variables for other things
+          const foundRemoved = REMOVED_ENVS.find((removed) => removed === key);
+          if (foundRemoved) {
+            errors.push(
+              `CONFIG NOT RECOGNIZED: Environment variable "${key}" no longer used`
+            );
+          } else {
+            warnings.push(
+              `CONFIG NOT RECOGNIZED: Environment variable "${key}"`
+            );
+          }
         }
       }
     });

--- a/server/test/lib/config.js
+++ b/server/test/lib/config.js
@@ -87,6 +87,18 @@ describe('lib/config', function () {
     assert(found, 'has error about old key');
   });
 
+  it('Warns for unknown env var', function () {
+    const config = new Config({}, { SQLPAD_UNKNOWN_VAR: 'true' });
+    const validations = config.getValidations();
+    assert(validations.warnings);
+    const found = validations.warnings.find(
+      (warning) =>
+        warning.includes('SQLPAD_UNKNOWN_VAR') &&
+        warning.includes('NOT RECOGNIZED')
+    );
+    assert(found, 'has warning about unknown key');
+  });
+
   it('Errors env connection missing name', function () {
     const config = new Config(
       {},


### PR DESCRIPTION
Updates unknown key check. If a known old environment variable is used that is no longer supported, an error is logged and startup is halted. For any other unknown variable, a warning is logged and startup is continued.

Fixes  #938 