### PR TITLE
postgres sslmode with self-signed certificates (fixes #954)

### DIFF
--- a/docs/connections.md
+++ b/docs/connections.md
@@ -152,6 +152,7 @@ A default connection selection can be set using environment variable `SQLPAD_DEF
 | `username`                         | Database Username                                     |   text    |
 | `password`                         | Database Password                                     |   text    |
 | `postgresSsl`                      | Use SSL                                               |  boolean  |
+| `postgresSslSelfSigned`            | Allow self-signed SSL certificate                     |  boolean  |
 | `postgresCert`                     | Database Certificate Path                             |   text    |
 | `postgresKey`                      | Database Key Path                                     |   text    |
 | `postgresCA`                       | Database CA Path                                      |   text    |

--- a/server/drivers/postgres/index.js
+++ b/server/drivers/postgres/index.js
@@ -40,6 +40,10 @@ class Client {
       if (connection.postgresCA) {
         pgConfig.ssl['ca'] = fs.readFileSync(connection.postgresCA);
       }
+    } else if (connection.postgresSsl && connection.postgresSslSelfSigned) {
+      pgConfig.ssl = {
+        rejectUnauthorized: false,
+      };
     }
 
     this.pgConfig = pgConfig;
@@ -211,6 +215,11 @@ const fields = [
     key: 'postgresSsl',
     formType: 'CHECKBOX',
     label: 'Use SSL',
+  },
+  {
+    key: 'postgresSslSelfSigned',
+    formType: 'CHECKBOX',
+    label: 'Allow self-signed SSL certificate',
   },
   {
     key: 'postgresCert',


### PR DESCRIPTION
As per #954:

It's impossible to connect to a Postgres instance via SSL using a self-signed certificate.

When the connection is configured and tested, the "self signed certificate" error appears (passed up from the underlying Postgres driver).

This is desirable because Heroku's free tier requires SSL mode and only offers self-signed certs.
