### PR TITLE
QueryResultDataTable CSS: degrade gracefully on Safari (fixes #959)

### DIFF
--- a/client/src/common/QueryResultDataTable.module.css
+++ b/client/src/common/QueryResultDataTable.module.css
@@ -62,7 +62,7 @@
   width: 16px;
   background-image: linear-gradient(
     to right,
-    rgba(255, 0, 0, 0),
+    rgba(255, 255, 255, 0),
     rgb(250, 250, 250)
   );
 }
@@ -75,7 +75,7 @@
   width: 16px;
   background-image: linear-gradient(
     to right,
-    rgba(255, 0, 0, 0),
+    rgba(255, 255, 255, 0),
     rgb(255, 255, 255)
   );
 }


### PR DESCRIPTION
Query data display grid renders a weird red border between columns on Safari.

* Safari before: <img width="147" alt="safari_before" src="https://user-images.githubusercontent.com/38443/108501858-92f5d500-72ba-11eb-9963-828db2cd1c3f.png">

* Safari after: <img width="183" alt="safari_after" src="https://user-images.githubusercontent.com/38443/108501851-90937b00-72ba-11eb-91c3-c00f4ed4963d.png">

* Chrome before: <img width="133" alt="chrome_before" src="https://user-images.githubusercontent.com/38443/108501837-8cfff400-72ba-11eb-8d47-cea7fcaa07d8.png">

* Chrome after: <img width="156" alt="chrome_after" src="https://user-images.githubusercontent.com/38443/108501832-8b363080-72ba-11eb-862b-5b099e878093.png">
