### PR TITLE
Fix uncatchable ldap error

### DIFF
--- a/server/auth-strategies/ldap.js
+++ b/server/auth-strategies/ldap.js
@@ -1,5 +1,4 @@
 const passport = require('passport');
-const ldap = require('ldapjs');
 const LdapStrategy = require('passport-ldapauth');
 const appLog = require('../lib/app-log');
 const ldapUtils = require('../lib/ldap-utils');
@@ -118,9 +117,8 @@ async function enableLdap(config) {
             roleSetByRBAC = true;
 
             // Establish LDAP client to make additional queries
-            const client = ldap.createClient({
-              url: config.get('ldapUrl'),
-            });
+            const client = ldapUtils.getClient(config);
+
             await ldapUtils.bindClient(client, bindDN, bindCredentials);
 
             try {


### PR DESCRIPTION
If an LDAP url is provided in config, an attempt to bind with url and credentials is made to validate the connection. A recent update to ldapjs throws an error somewhere deep within the implementation if a listener for the `error` event is not provided. 

This provides an error listener when establishing a connection. The error is logged and not acted on. The bind operation will also return an error in the event that a connection can not be established.