### PR TITLE
Add confirmation prompt when scrolling query results

### DIFF
--- a/client/src/queryEditor/EditorNavProtection.tsx
+++ b/client/src/queryEditor/EditorNavProtection.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Prompt } from 'react-router-dom';
+import { useMouseOverResultPane } from '../stores/editor-store';
+
+// Guard against accidental navigation away from query results
+//
+// At this time the only scenario protected against is when the user is scrolling back over query results
+// Scrolling too far can trigger the back navigation, which is often undesired
+// To protect against this, we track when the mouse is over query results.
+// If nav occurs we assume its probably from side scroll
+function EditorNavProtection() {
+  const mouseOverResultPane = useMouseOverResultPane();
+
+  return (
+    <Prompt
+      when={mouseOverResultPane}
+      message="Are you sure you want to leave?"
+    />
+  );
+}
+
+export default EditorNavProtection;

--- a/client/src/queryEditor/QueryEditor.tsx
+++ b/client/src/queryEditor/QueryEditor.tsx
@@ -7,6 +7,7 @@ import SchemaInfoLoader from '../schema/SchemaInfoLoader';
 import { connectConnectionClient, loadQuery } from '../stores/editor-actions';
 import useShortcuts from '../utilities/use-shortcuts';
 import DocumentTitle from './DocumentTitle';
+import EditorNavProtection from './EditorNavProtection';
 import EditorPaneRightSidebar from './EditorPaneRightSidebar';
 import EditorPaneSchemaSidebar from './EditorPaneSchemaSidebar';
 import EditorPaneVis from './EditorPaneVis';
@@ -81,6 +82,7 @@ function QueryEditor() {
       <SchemaInfoLoader />
       <QuerySaveModal />
       <NotFoundModal visible={showNotFound} queryId={queryId} />
+      <EditorNavProtection />
     </div>
   );
 }

--- a/client/src/queryEditor/QueryEditorResultPane.tsx
+++ b/client/src/queryEditor/QueryEditorResultPane.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import QueryResultContainer from '../common/QueryResultContainer';
 import QueryResultRunning from '../common/QueryResultRunning';
+import { setMouseOverResultPane } from '../stores/editor-actions';
 import {
   useSessionBatch,
   useSessionIsRunning,
@@ -44,7 +45,10 @@ function QueryEditorResultPane() {
   }
 
   return (
-    <div>
+    <div
+      onMouseOver={() => setMouseOverResultPane(true)}
+      onMouseLeave={() => setMouseOverResultPane(false)}
+    >
       <QueryResultHeader />
       <div
         style={{

--- a/client/src/stores/editor-actions.ts
+++ b/client/src/stores/editor-actions.ts
@@ -190,6 +190,10 @@ export function toggleShowQueryModal() {
   setState({ showQueryModal: !showQueryModal });
 }
 
+export function setMouseOverResultPane(mouseOverResultPane: boolean) {
+  setState({ mouseOverResultPane });
+}
+
 /**
  * Reset state (on signout for example)
  */

--- a/client/src/stores/editor-store.ts
+++ b/client/src/stores/editor-store.ts
@@ -52,6 +52,7 @@ export interface EditorSession {
 export type EditorStoreState = {
   initialized: boolean;
   showQueryModal: boolean;
+  mouseOverResultPane: boolean;
   focusedSessionId: string;
   editorSessions: Record<string, EditorSession>;
   batches: Record<string, Batch>;
@@ -96,6 +97,7 @@ export const INITIAL_SESSION: EditorSession = {
 export const INITIAL_STATE = {
   initialized: false,
   showQueryModal: false,
+  mouseOverResultPane: false,
   focusedSessionId: INITIAL_SESSION_ID,
   editorSessions: {
     [INITIAL_SESSION_ID]: INITIAL_SESSION,
@@ -127,6 +129,10 @@ export function useInitialized() {
 
 export function useShowQueryModal() {
   return useEditorStore((s) => s.showQueryModal);
+}
+
+export function useMouseOverResultPane() {
+  return useEditorStore((s) => s.mouseOverResultPane);
 }
 
 export function useSessionQueryShared() {


### PR DESCRIPTION
Prevents accidental back navigation while scrolling query results. If mouse is detected over query result pane, and a navigation is triggered, a prompt is shown.

Fixes #963 