### PR TITLE
Add copy cell value context menu

### DIFF
--- a/client/src/common/QueryResultDataTable.tsx
+++ b/client/src/common/QueryResultDataTable.tsx
@@ -73,7 +73,7 @@ function OffScreenInput({ id, value }: { id: string; value: string }) {
 function CopyMenuItem({ id, value }: { id: string; value: string }) {
   let displayValue = value;
   if (value.length > 30) {
-    displayValue = value.substring(0, 30) + '…';
+    displayValue = value.substring(0, 30).trim() + '…';
   }
 
   return (


### PR DESCRIPTION
Adds context menu to query result cell to copy cell value text. This can be helpful in copying large text values in cells where the value is cut off. 

fixes #661 