### PR TITLE
Fix object and date value strings in CSV and XLSX

### DIFF
--- a/server/routes/statement-results.js
+++ b/server/routes/statement-results.js
@@ -22,8 +22,6 @@ const renderValue = (input, column) => {
     return input.substring(0, 10);
   } else if (typeof input === 'object') {
     return JSON.stringify(input, null, 2);
-  } else if (typeof input === 'string') {
-    return input;
   } else {
     return input;
   }

--- a/server/routes/statement-results.js
+++ b/server/routes/statement-results.js
@@ -9,6 +9,26 @@ const sanitize = require('sanitize-filename');
 
 const FORMATS = ['csv', 'json', 'xlsx'];
 
+const renderValue = (input, column) => {
+  if (input === null || input === undefined) {
+    return null;
+  } else if (input === true || input === false) {
+    return input;
+  } else if (column.datatype === 'datetime' && typeof input === 'string') {
+    // Remove the letters from ISO string and present as is
+    return input.replace('T', ' ').replace('Z', '');
+  } else if (column.datatype === 'date' && typeof input === 'string') {
+    // Formats ISO string to YYYY-MM-DD
+    return input.substring(0, 10);
+  } else if (typeof input === 'object') {
+    return JSON.stringify(input, null, 2);
+  } else if (typeof input === 'string') {
+    return input;
+  } else {
+    return input;
+  }
+};
+
 /**
  * NOTE: This is not an `/api/` route, so the responses here are not JSON
  *
@@ -57,9 +77,23 @@ async function handleDownload(req, res) {
     'attachment; filename="' + filename + '"'
   );
 
+  // Convert row data to formats for exports
+  // Currently this JSON stringifies objects and arrays,
+  // and strips the T and Z from JSON stringified date strings
+  // TODO - for xlsx export, we should see if possible to get values formatted correctly in file
+  // For example, sending a date object doesn't make it a date cell
+  // Unsure if node-xlsx (https://www.npmjs.com/package/node-xlsx) supports this.
+  // May need to use xlsx package directly (https://www.npmjs.com/package/xlsx)
+  const rowsForExport = rows.map((row) => {
+    const convertedRow = statement.columns.map((col, index) =>
+      renderValue(row[index], col)
+    );
+    return convertedRow;
+  });
+
   if (format === 'csv') {
     res.setHeader('Content-Type', 'text/csv');
-    const csvData = papa.unparse([columnNames].concat(rows));
+    const csvData = papa.unparse([columnNames].concat(rowsForExport));
     return res.send(csvData);
   }
 
@@ -69,7 +103,7 @@ async function handleDownload(req, res) {
       'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
     );
     const xlsxBuffer = xlsx.build([
-      { name: 'query-results', data: [columnNames].concat(rows) },
+      { name: 'query-results', data: [columnNames].concat(rowsForExport) },
     ]);
     return res.send(xlsxBuffer);
   }


### PR DESCRIPTION
Cleans up value strings for CSV and XLSX data exports. Objects are no longer rendered [object object] and date and datetime values no longer render with the T and Z values. Formatting matches what is rendered in the result grid.

There is still room for improvement for the XLSX export here. Dates should be treated as date values when opened with Excel or similar.

Partial improvement for #958 