### PR TITLE
Render connection name when hiding connection dropdown

### DIFF
--- a/client/src/queryEditor/ConnectionDropdown.tsx
+++ b/client/src/queryEditor/ConnectionDropdown.tsx
@@ -41,7 +41,12 @@ function ConnectionDropdown() {
 
   // Only show the connection menu if there's more than one option to select.
   if (currentUser?.role === 'editor' && connections.length === 1) {
-    return null;
+    const name = connections.find((c) => c.id === selectedConnectionId)?.name;
+    return (
+      <div style={{ height: 32, lineHeight: '32px', padding: '0 8px' }}>
+        {name || ''}
+      </div>
+    );
   }
 
   const style = !selectedConnectionId


### PR DESCRIPTION
Fixes #932 

Displays connection name if user is editor role and only has access to a single connection. Previously the dropdown is hidden, making it unclear as to what database is selected.

![single-connection-editor](https://user-images.githubusercontent.com/303966/110840833-cea50e80-826a-11eb-929a-7c2b641eebfc.jpg)
