### PR TITLE
Add cell expanded value modal

### DIFF
--- a/client/src/common/Modal.module.css
+++ b/client/src/common/Modal.module.css
@@ -9,7 +9,7 @@
   justify-content: space-between;
   box-sizing: border-box;
   flex: 0 0 45px;
-  font-size: 1.3rem;
+  font-size: 1.2rem;
   padding: 8px 16px;
   line-height: 1.5;
   align-items: center;
@@ -18,4 +18,7 @@
 
 .dialogBody {
   padding: 16px;
+  max-width: 80vw;
+  overflow-x: auto;
+  margin-right: 32px;
 }


### PR DESCRIPTION
Adds another entry to cell value context menu to expand value. Clicking that opens the cell value in a modal to show the full value.

![sqlpad-copy-context-menu](https://user-images.githubusercontent.com/303966/110892635-05eedc00-82ba-11eb-85f7-3df3f1aa4213.jpg)
![sqlpad-expanded-value](https://user-images.githubusercontent.com/303966/110892638-06877280-82ba-11eb-92fb-d5e31bbd2b39.jpg)
