### PR TITLE
Set base during development only

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -54,8 +54,8 @@
   },
   "scripts": {
     "analyze": "cross-env SOURCEMAP=true npm run build && source-map-explorer \"build/assets/*.js\" --html bundle-analysis-result.html",
-    "build": "tsc && vite build",
-    "start": "vite",
+    "build": "cross-env NODE_ENV=production tsc && vite build",
+    "start": "cross-env NODE_ENV=development vite",
     "fixlint": "eslint --fix \"**/*.{js,jsx,ts,tsx}\"",
     "lint": "eslint \"**/*.{js,jsx,ts,tsx}\"",
     "dev": "vite",

--- a/client/package.json
+++ b/client/package.json
@@ -54,8 +54,8 @@
   },
   "scripts": {
     "analyze": "cross-env SOURCEMAP=true npm run build && source-map-explorer \"build/assets/*.js\" --html bundle-analysis-result.html",
-    "build": "cross-env NODE_ENV=production tsc && vite build",
-    "start": "cross-env NODE_ENV=development vite",
+    "build": "tsc && vite build",
+    "start": "vite",
     "fixlint": "eslint --fix \"**/*.{js,jsx,ts,tsx}\"",
     "lint": "eslint \"**/*.{js,jsx,ts,tsx}\"",
     "dev": "vite",

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import reactRefresh from '@vitejs/plugin-react-refresh';
 
 const sourcemap = process.env.SOURCEMAP === 'true';
+const isProduction = process.env.NODE_ENV === 'production';
 
 // For each route prefix below, add proxy entry to http://localhost:3010
 // Add another set with '/sqlpad' prefix, as that base url is used during dev/testing
@@ -31,7 +32,7 @@ proxy['^/.*/api/app'] = PROXY_URL;
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: '/sqlpad/',
+  base: isProduction ? undefined : '/sqlpad/',
   plugins: [reactRefresh()],
   server: {
     proxy,

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,8 +1,6 @@
-import { defineConfig } from 'vite';
 import reactRefresh from '@vitejs/plugin-react-refresh';
 
 const sourcemap = process.env.SOURCEMAP === 'true';
-const isProduction = process.env.NODE_ENV === 'production';
 
 // For each route prefix below, add proxy entry to http://localhost:3010
 // Add another set with '/sqlpad' prefix, as that base url is used during dev/testing
@@ -31,14 +29,25 @@ PROXY_ROUTES.forEach((route) => {
 proxy['^/.*/api/app'] = PROXY_URL;
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  base: isProduction ? undefined : '/sqlpad/',
-  plugins: [reactRefresh()],
-  server: {
-    proxy,
-  },
-  build: {
-    outDir: 'build',
-    sourcemap,
-  },
-});
+const getConfig = ({ command, mode }) => {
+  let base = undefined;
+
+  // command is either build or serve
+  if (command === 'serve') {
+    base = '/sqlpad/';
+  }
+
+  return {
+    base,
+    plugins: [reactRefresh()],
+    server: {
+      proxy,
+    },
+    build: {
+      outDir: 'build',
+      sourcemap,
+    },
+  };
+};
+
+export default getConfig;


### PR DESCRIPTION
The vite config for base url to `/sqlpad` is getting set during production build as well.

Fixes #982 