### PR TITLE
Add query run history viewer

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -37,6 +37,7 @@
         "mdi-react": "^7.4.0",
         "mitt": "^2.1.0",
         "parse-link-header": "^1.0.1",
+        "prism-react-renderer": "^1.2.0",
         "prop-types": "^15.7.2",
         "query-string": "^6.13.8",
         "react": "^17.0.1",
@@ -3574,6 +3575,14 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/prism-react-renderer": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-1.2.0.tgz",
+      "integrity": "sha512-GHqzxLYImx1iKN1jJURcuRoA/0ygCcNhfGw1IT8nPIMzarmKQ3Nc+JcG0gi8JXQzuh0C5ShE4npMIoqNin40hg==",
+      "peerDependencies": {
+        "react": ">=0.14.9"
       }
     },
     "node_modules/progress": {
@@ -7220,6 +7229,12 @@
         "ansi-styles": "^4.0.0",
         "react-is": "^17.0.1"
       }
+    },
+    "prism-react-renderer": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-1.2.0.tgz",
+      "integrity": "sha512-GHqzxLYImx1iKN1jJURcuRoA/0ygCcNhfGw1IT8nPIMzarmKQ3Nc+JcG0gi8JXQzuh0C5ShE4npMIoqNin40hg==",
+      "requires": {}
     },
     "progress": {
       "version": "2.0.3",

--- a/client/package.json
+++ b/client/package.json
@@ -32,6 +32,7 @@
     "mdi-react": "^7.4.0",
     "mitt": "^2.1.0",
     "parse-link-header": "^1.0.1",
+    "prism-react-renderer": "^1.2.0",
     "prop-types": "^15.7.2",
     "query-string": "^6.13.8",
     "react": "^17.0.1",

--- a/client/src/common/Code.module.css
+++ b/client/src/common/Code.module.css
@@ -1,4 +1,4 @@
-pre {
+.pre {
   font-family: 'Courier 10 Pitch', Courier, monospace;
   font-size: 95%;
   line-height: 140%;
@@ -6,7 +6,7 @@ pre {
   word-wrap: break-word;
 }
 
-code {
+.code {
   font-family: Monaco, Consolas, 'Andale Mono', 'DejaVu Sans Mono', monospace;
   font-size: 95%;
   line-height: 140%;

--- a/client/src/common/Code.tsx
+++ b/client/src/common/Code.tsx
@@ -6,7 +6,7 @@ export interface Props extends React.HTMLAttributes<HTMLElement> {
 }
 
 const Code = ({ children, className, type, ...rest }: Props) => {
-  const cs = [];
+  const cs = [styles.code];
 
   if (className) {
     cs.push(className);
@@ -17,7 +17,7 @@ const Code = ({ children, className, type, ...rest }: Props) => {
   }
 
   return (
-    <pre>
+    <pre className={styles.pre}>
       <code className={cs.join(' ')} {...rest}>
         {children}
       </code>

--- a/client/src/css/index.css
+++ b/client/src/css/index.css
@@ -139,6 +139,28 @@ input {
   text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.5);
 }
 
+.sp-error {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: auto;
+
+  font-size: 1.3rem;
+  padding: 16px;
+  text-align: center;
+  color: hsl(323, 100%, 42%);
+}
+
+.sp-info {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  font-size: 1.3rem;
+  padding: 16px;
+  text-align: center;
+}
+
 /* Might be trying out more of just plain css, less of css.modules */
 .sp-error-block {
   height: 100%;
@@ -163,7 +185,7 @@ input {
   align-items: center;
 
   font-size: 1.3rem;
-  padding: 24px;
+  padding: 16px;
   text-align: center;
 }
 

--- a/client/src/queryEditor/HistoryDrawer.tsx
+++ b/client/src/queryEditor/HistoryDrawer.tsx
@@ -48,95 +48,107 @@ function HistoryDrawer({ onClose, visible }: Props) {
     if (queryBatches.length === 0) {
       content = (
         <div style={{ height: 150, width: '100%' }}>
-          <InfoBlock>No queries found</InfoBlock>
+          <InfoBlock>No run history found for this query.</InfoBlock>
         </div>
       );
-    }
-    content = queryBatches
-      .map((batch) => {
-        return (
-          <div
-            key={batch.id}
-            style={{
-              border: '1px solid #eee',
-              padding: 8,
-              marginTop: 16,
-              marginBottom: 16,
-            }}
-          >
-            <h2 style={{ fontSize: '1rem' }}>{batch.createdAtCalendar}</h2>
-            <div style={{ marginBottom: 16 }}>
-              {capitalize(batch.status)} in {humanizeDuration(batch.durationMs)}
-            </div>
-            <Highlight
-              {...defaultProps}
-              theme={theme}
-              code={batch.selectedText || batch.batchText}
-              language="sql"
+    } else {
+      content = queryBatches
+        .map((batch) => {
+          return (
+            <div
+              key={batch.id}
+              style={{
+                border: '1px solid #eee',
+                padding: 8,
+                marginTop: 16,
+                marginBottom: 16,
+              }}
             >
-              {({ className, style, tokens, getLineProps, getTokenProps }) => (
-                <pre className={className} style={style}>
-                  {tokens.map((line, i) => (
-                    <div {...getLineProps({ line, key: i })}>
-                      {line.map((token, key) => (
-                        <span {...getTokenProps({ token, key })} />
-                      ))}
-                    </div>
-                  ))}
-                </pre>
-              )}
-            </Highlight>
-            {!batch.statements &&
-            (batch.status === 'finished' || batch.status === 'error') ? (
-              <div className="sp-info" style={{ fontSize: '1rem' }}>
-                Query results purged from storage
+              <h2 style={{ fontSize: '1rem' }}>{batch.createdAtCalendar}</h2>
+              <div style={{ marginBottom: 16 }}>
+                {capitalize(batch.status)} in{' '}
+                {humanizeDuration(batch.durationMs)}
               </div>
-            ) : null}
-            {(batch.statements || []).map((statement) => {
-              if (statement.error) {
-                return (
-                  <div
-                    key={statement.id}
-                    className="sp-error"
-                    style={{ fontSize: '1rem' }}
-                  >
-                    {statement.error.title}
-                  </div>
-                );
-              }
+              <Highlight
+                {...defaultProps}
+                theme={theme}
+                code={batch.selectedText || batch.batchText}
+                language="sql"
+              >
+                {({
+                  className,
+                  style,
+                  tokens,
+                  getLineProps,
+                  getTokenProps,
+                }) => (
+                  <pre className={className} style={style}>
+                    {tokens.map((line, i) => (
+                      <div {...getLineProps({ line, key: i })}>
+                        {line.map((token, key) => (
+                          <span {...getTokenProps({ token, key })} />
+                        ))}
+                      </div>
+                    ))}
+                  </pre>
+                )}
+              </Highlight>
+              {!batch.statements &&
+              (batch.status === 'finished' || batch.status === 'error') ? (
+                <div className="sp-info" style={{ fontSize: '1rem' }}>
+                  Query results purged from storage
+                </div>
+              ) : null}
+              {(batch.statements || []).map((statement) => {
+                if (statement.error) {
+                  return (
+                    <div
+                      key={statement.id}
+                      className="sp-error"
+                      style={{ fontSize: '1rem' }}
+                    >
+                      {statement.error.title}
+                    </div>
+                  );
+                }
 
-              return (
-                <table
-                  key={statement.id}
-                  className={styles.table}
-                  style={{ border: 'var(--border)' }}
-                >
-                  <thead>
-                    <tr>
-                      {(statement?.columns || []).map((column) => (
-                        <th>{column.name}</th>
-                      ))}
-                    </tr>
-                    <tr>
-                      <td
-                        style={{ textAlign: 'center' }}
-                        colSpan={(statement?.columns || []).length}
-                      >
-                        <em>
-                          {statement.rowCount}{' '}
-                          {statement.rowCount === 1 ? 'row' : 'rows'}
-                          {statement.incomplete ? '(incomplete)' : ''}
-                        </em>
-                      </td>
-                    </tr>
-                  </thead>
-                </table>
-              );
-            })}
-          </div>
-        );
-      })
-      .concat([<div key="bottom" ref={bottomEl} />]);
+                if (statement.status !== 'finished') {
+                  return null;
+                }
+
+                return (
+                  <table
+                    key={statement.id}
+                    className={styles.table}
+                    style={{ border: 'var(--border)', marginTop: 8 }}
+                  >
+                    <thead>
+                      <tr>
+                        {(statement?.columns || []).map((column) => (
+                          <th>{column.name}</th>
+                        ))}
+                      </tr>
+                      <tr>
+                        <td
+                          style={{ textAlign: 'center' }}
+                          colSpan={(statement?.columns || []).length}
+                        >
+                          <em>
+                            {statement.rowCount}{' '}
+                            {statement.rowCount === 1 ? 'row' : 'rows'}
+                            {statement.incomplete ? '(incomplete)' : ''}
+                          </em>
+                        </td>
+                      </tr>
+                    </thead>
+                  </table>
+                );
+              })}
+            </div>
+          );
+        })
+        .concat([<div key="bottom" ref={bottomEl} />]);
+    }
   }
 
   const batchLength = queryBatches ? queryBatches.length : 0;

--- a/client/src/queryEditor/HistoryDrawer.tsx
+++ b/client/src/queryEditor/HistoryDrawer.tsx
@@ -166,9 +166,7 @@ function HistoryDrawer({ onClose, visible }: Props) {
   const batchLength = queryBatches ? queryBatches.length : 0;
   useEffect(() => {
     if (visible && batchLength > 0) {
-      setTimeout(() => {
-        bottomEl && bottomEl.current && bottomEl.current.scrollIntoView(false);
-      });
+      bottomEl && bottomEl.current && bottomEl.current.scrollIntoView(false);
     }
   }, [batchLength, visible]);
 

--- a/client/src/queryEditor/HistoryDrawer.tsx
+++ b/client/src/queryEditor/HistoryDrawer.tsx
@@ -86,7 +86,8 @@ function HistoryDrawer({ onClose, visible }: Props) {
                 </pre>
               )}
             </Highlight>
-            {!batch.statements && batch.status === 'finished' ? (
+            {!batch.statements &&
+            (batch.status === 'finished' || batch.status === 'error') ? (
               <div className="sp-info" style={{ fontSize: '1rem' }}>
                 Query results purged from storage
               </div>

--- a/client/src/queryEditor/HistoryDrawer.tsx
+++ b/client/src/queryEditor/HistoryDrawer.tsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useRef } from 'react';
+import Highlight, { defaultProps } from 'prism-react-renderer';
 import Drawer from '../common/Drawer';
 import ErrorBlock from '../common/ErrorBlock';
 import InfoBlock from '../common/InfoBlock';
 import SpinKitCube from '../common/SpinKitCube';
 import { api } from '../utilities/api';
+import theme from 'prism-react-renderer/themes/vsLight';
 
 type Props = {
   visible?: boolean;
@@ -49,7 +51,24 @@ function HistoryDrawer({ onClose, visible }: Props) {
           <div key={batch.id}>
             <div>{batch.createdAt}</div>
             <div>{batch.status}</div>
-            <pre>{batch.batchText}</pre>
+            <Highlight
+              {...defaultProps}
+              theme={theme}
+              code={batch.batchText}
+              language="sql"
+            >
+              {({ className, style, tokens, getLineProps, getTokenProps }) => (
+                <pre className={className} style={style}>
+                  {tokens.map((line, i) => (
+                    <div {...getLineProps({ line, key: i })}>
+                      {line.map((token, key) => (
+                        <span {...getTokenProps({ token, key })} />
+                      ))}
+                    </div>
+                  ))}
+                </pre>
+              )}
+            </Highlight>
             {(batch.statements || []).map((statement) => {
               return <div key={statement.id}>{statement.durationMs}</div>;
             })}

--- a/client/src/queryEditor/HistoryDrawer.tsx
+++ b/client/src/queryEditor/HistoryDrawer.tsx
@@ -1,17 +1,17 @@
-import React, { useEffect, useRef } from 'react';
-import Highlight, { defaultProps } from 'prism-react-renderer';
 import humanizeDuration from 'humanize-duration';
 import capitalize from 'lodash/capitalize';
+import Highlight, { defaultProps } from 'prism-react-renderer';
+import theme from 'prism-react-renderer/themes/vsLight';
+import React, { useEffect, useRef } from 'react';
+import Button from '../common/Button';
 import Drawer from '../common/Drawer';
 import ErrorBlock from '../common/ErrorBlock';
 import InfoBlock from '../common/InfoBlock';
 import SpinKitCube from '../common/SpinKitCube';
-import { api } from '../utilities/api';
-import theme from 'prism-react-renderer/themes/vsLight';
-import { useSessionQueryId, useSessionQueryName } from '../stores/editor-store';
-import styles from './StatementsTable.module.css';
-import Button from '../common/Button';
 import { setEditorBatchHistoryItem } from '../stores/editor-actions';
+import { useSessionQueryId, useSessionQueryName } from '../stores/editor-store';
+import { api } from '../utilities/api';
+import styles from './StatementsTable.module.css';
 
 type Props = {
   visible?: boolean;
@@ -25,16 +25,22 @@ function HistoryDrawer({ onClose, visible }: Props) {
   const queryId = useSessionQueryId() || 'null';
   const queryName = useSessionQueryName() || 'unsaved queries';
 
-  let {
+  const {
     data: queryBatches,
     error: queryBatchHistoryError,
   } = api.useQueryBatchHistory(queryId);
 
   const fetching = !queryBatches;
 
-  function handleClose() {
-    onClose();
-  }
+  const batchLength = queryBatches ? queryBatches.length : 0;
+  useEffect(() => {
+    if (visible && batchLength > 0) {
+      // Without setTimeout this fires too soon? This is sort of hacky and could be fragile
+      setTimeout(() => {
+        bottomEl && bottomEl.current && bottomEl.current.scrollIntoView(false);
+      }, 50);
+    }
+  }, [batchLength, visible]);
 
   let content = null;
 
@@ -60,7 +66,7 @@ function HistoryDrawer({ onClose, visible }: Props) {
             <div
               key={batch.id}
               style={{
-                border: '1px solid #eee',
+                border: 'var(--border)',
                 padding: 8,
                 marginTop: 16,
                 marginBottom: 16,
@@ -76,7 +82,7 @@ function HistoryDrawer({ onClose, visible }: Props) {
                 style={{ position: 'absolute', top: 8, right: 8 }}
                 onClick={() => {
                   setEditorBatchHistoryItem(batch);
-                  handleClose();
+                  onClose();
                 }}
               >
                 Open in editor
@@ -163,19 +169,12 @@ function HistoryDrawer({ onClose, visible }: Props) {
     }
   }
 
-  const batchLength = queryBatches ? queryBatches.length : 0;
-  useEffect(() => {
-    if (visible && batchLength > 0) {
-      bottomEl && bottomEl.current && bottomEl.current.scrollIntoView(false);
-    }
-  }, [batchLength, visible]);
-
   return (
     <Drawer
       title={`Run history for ${queryName}`}
       visible={visible}
-      width={'80vw'}
-      onClose={handleClose}
+      width={'70vw'}
+      onClose={onClose}
       placement="right"
     >
       <div

--- a/client/src/queryEditor/HistoryDrawer.tsx
+++ b/client/src/queryEditor/HistoryDrawer.tsx
@@ -1,0 +1,90 @@
+import React, { useEffect, useRef } from 'react';
+import Drawer from '../common/Drawer';
+import ErrorBlock from '../common/ErrorBlock';
+import InfoBlock from '../common/InfoBlock';
+import SpinKitCube from '../common/SpinKitCube';
+import { api } from '../utilities/api';
+
+type Props = {
+  visible?: boolean;
+  onClose: (...args: any[]) => any;
+};
+
+function HistoryDrawer({ onClose, visible }: Props) {
+  const bottomEl = useRef<HTMLDivElement>(null);
+  const containerEl = useRef<HTMLDivElement>(null);
+
+  let {
+    data: queryBatches,
+    error: queryBatchHistoryError,
+  } = api.useQueryBatchHistory('null');
+
+  const fetching = !queryBatches;
+
+  function handleClose() {
+    onClose();
+  }
+
+  let content = null;
+
+  if (fetching) {
+    content = (
+      <div className="h-100 w-100 flex-center">
+        <SpinKitCube />
+      </div>
+    );
+  } else if (queryBatchHistoryError) {
+    content = <ErrorBlock>Error getting execution history</ErrorBlock>;
+  } else if (queryBatches) {
+    if (queryBatches.length === 0) {
+      content = (
+        <div style={{ height: 150, width: '100%' }}>
+          <InfoBlock>No queries found</InfoBlock>
+        </div>
+      );
+    }
+    content = queryBatches
+      .map((batch) => {
+        return (
+          <div key={batch.id}>
+            <div>{batch.createdAt}</div>
+            <div>{batch.status}</div>
+            <pre>{batch.batchText}</pre>
+            {(batch.statements || []).map((statement) => {
+              return <div key={statement.id}>{statement.durationMs}</div>;
+            })}
+            <hr />
+          </div>
+        );
+      })
+      .concat([<div key="bottom" ref={bottomEl} />]);
+  }
+
+  const batchLength = queryBatches ? queryBatches.length : 0;
+  useEffect(() => {
+    if (visible && batchLength > 0) {
+      setTimeout(() => {
+        bottomEl && bottomEl.current && bottomEl.current.scrollIntoView(false);
+      });
+    }
+  }, [batchLength, visible]);
+
+  return (
+    <Drawer
+      title={'Execution History for ...'}
+      visible={visible}
+      width={'80vw'}
+      onClose={handleClose}
+      placement="right"
+    >
+      <div
+        ref={containerEl}
+        style={{ display: 'flex', flexDirection: 'column', height: '100%' }}
+      >
+        {content}
+      </div>
+    </Drawer>
+  );
+}
+
+export default React.memo(HistoryDrawer);

--- a/client/src/queryEditor/HistoryDrawer.tsx
+++ b/client/src/queryEditor/HistoryDrawer.tsx
@@ -10,6 +10,8 @@ import { api } from '../utilities/api';
 import theme from 'prism-react-renderer/themes/vsLight';
 import { useSessionQueryId, useSessionQueryName } from '../stores/editor-store';
 import styles from './StatementsTable.module.css';
+import Button from '../common/Button';
+import { setEditorBatchHistoryItem } from '../stores/editor-actions';
 
 type Props = {
   visible?: boolean;
@@ -62,6 +64,7 @@ function HistoryDrawer({ onClose, visible }: Props) {
                 padding: 8,
                 marginTop: 16,
                 marginBottom: 16,
+                position: 'relative',
               }}
             >
               <h2 style={{ fontSize: '1rem' }}>{batch.createdAtCalendar}</h2>
@@ -69,6 +72,15 @@ function HistoryDrawer({ onClose, visible }: Props) {
                 {capitalize(batch.status)} in{' '}
                 {humanizeDuration(batch.durationMs)}
               </div>
+              <Button
+                style={{ position: 'absolute', top: 8, right: 8 }}
+                onClick={() => {
+                  setEditorBatchHistoryItem(batch);
+                  handleClose();
+                }}
+              >
+                Open in editor
+              </Button>
               <Highlight
                 {...defaultProps}
                 theme={theme}
@@ -125,7 +137,7 @@ function HistoryDrawer({ onClose, visible }: Props) {
                     <thead>
                       <tr>
                         {(statement?.columns || []).map((column) => (
-                          <th>{column.name}</th>
+                          <th key={column.name}>{column.name}</th>
                         ))}
                       </tr>
                       <tr>

--- a/client/src/queryEditor/Toolbar.tsx
+++ b/client/src/queryEditor/Toolbar.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ConnectionDropDown from './ConnectionDropdown';
 import ToolbarChartButton from './ToolbarChartButton';
 import ToolbarConnectionClientButton from './ToolbarConnectionClientButton';
+import ToolbarHistoryButton from './ToolbarHistoryButton';
 import ToolbarQueryName from './ToolbarQueryName';
 import ToolbarRunButton from './ToolbarRunButton';
 import ToolbarSpacer from './ToolbarSpacer';
@@ -27,6 +28,7 @@ function Toolbar() {
         <ToolbarSpacer grow />
         <ToolbarRunButton />
         <ToolbarSpacer />
+        <ToolbarHistoryButton />
         <ToolbarChartButton />
       </div>
     </div>

--- a/client/src/queryEditor/ToolbarHistoryButton.tsx
+++ b/client/src/queryEditor/ToolbarHistoryButton.tsx
@@ -9,7 +9,7 @@ function ToolbarHistoryButton() {
   return (
     <>
       <IconButton
-        tooltip="Configure visualization"
+        tooltip="View query run history"
         onClick={() => setShow(true)}
       >
         <HistoryIcon />

--- a/client/src/queryEditor/ToolbarHistoryButton.tsx
+++ b/client/src/queryEditor/ToolbarHistoryButton.tsx
@@ -1,0 +1,22 @@
+import HistoryIcon from 'mdi-react/HistoryIcon';
+import React, { useState } from 'react';
+import IconButton from '../common/IconButton';
+import HistoryDrawer from './HistoryDrawer';
+
+function ToolbarHistoryButton() {
+  const [show, setShow] = useState(false);
+
+  return (
+    <>
+      <IconButton
+        tooltip="Configure visualization"
+        onClick={() => setShow(true)}
+      >
+        <HistoryIcon />
+      </IconButton>
+      {show && <HistoryDrawer visible={show} onClose={() => setShow(false)} />}
+    </>
+  );
+}
+
+export default React.memo(ToolbarHistoryButton);

--- a/client/src/stores/editor-actions.ts
+++ b/client/src/stores/editor-actions.ts
@@ -5,6 +5,7 @@ import {
   ACLRecord,
   AppInfo,
   Batch,
+  BatchHistoryItem,
   ChartFields,
   Connection,
   ConnectionClient,
@@ -461,6 +462,35 @@ export const runQuery = async () => {
   setSession(focusedSessionId, {
     isRunning: false,
   });
+};
+
+export const setEditorBatchHistoryItem = async (
+  batchHistoryItem: BatchHistoryItem
+) => {
+  const { focusedSessionId } = getState();
+
+  // Statements might not exist if query result data is purged
+  // In that case, just restore the SQL and chart config and similar
+  // clear out batchId/selectedStatementId
+  const hasStatements = batchHistoryItem.statements;
+
+  setSession(focusedSessionId, {
+    queryName: batchHistoryItem.name,
+    queryText: batchHistoryItem.batchText,
+    chartType: batchHistoryItem.chart?.chartType,
+    chartFields: batchHistoryItem.chart?.fields,
+    connectionId: batchHistoryItem.connectionId,
+    connectionClient: undefined,
+    selectedText: '',
+    batchId: hasStatements ? batchHistoryItem.id : undefined,
+    selectedStatementId: undefined,
+    isRunning: false,
+    runQueryStartTime: batchHistoryItem.startTime,
+  });
+
+  if (hasStatements) {
+    setBatch(focusedSessionId, batchHistoryItem.id, batchHistoryItem);
+  }
 };
 
 export const saveQuery = async (additionalUpdates?: Partial<EditorSession>) => {

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -76,6 +76,12 @@ export interface Batch {
   updatedAt: string | Date;
 }
 
+export interface BatchHistoryItem extends Batch {
+  startTimeCalendar: string | Date;
+  stopTimeCalendar: string | Date;
+  createdAtCalendar: string | Date;
+}
+
 export type ConnectionFields = Record<string, any>;
 
 export interface ConnectionDetail extends ConnectionFields {

--- a/client/src/utilities/api.ts
+++ b/client/src/utilities/api.ts
@@ -5,6 +5,7 @@ import message from '../common/message';
 import {
   AppInfo,
   Batch,
+  BatchHistoryItem,
   Connection,
   ConnectionAccess,
   ConnectionDetail,
@@ -130,7 +131,7 @@ export const api = {
   },
 
   useQueryBatchHistory(queryId: string) {
-    return useSWR<Batch[]>(
+    return useSWR<BatchHistoryItem[]>(
       `/api/batches?queryId=${queryId}&includeStatements=true`
     );
   },

--- a/client/src/utilities/api.ts
+++ b/client/src/utilities/api.ts
@@ -129,6 +129,12 @@ export const api = {
     return useSWR<Batch>(`/api/batches/${batchId}`);
   },
 
+  useQueryBatchHistory(queryId: string) {
+    return useSWR<Batch[]>(
+      `/api/batches?queryId=${queryId}&includeStatements=true`
+    );
+  },
+
   getStatementResults(statementId: string) {
     return this.get<StatementResults>(`/api/statements/${statementId}/results`);
   },

--- a/server/models/batches.js
+++ b/server/models/batches.js
@@ -71,6 +71,9 @@ class Batches {
       const statementsByBatchId = _.groupBy(statements, 'batchId');
       batches.forEach((batch) => {
         batch.statements = statementsByBatchId[batch.id];
+        if (batch.statements) {
+          _.sortBy(batch.statements, ['sequence']);
+        }
       });
     }
 

--- a/server/models/batches.js
+++ b/server/models/batches.js
@@ -47,10 +47,18 @@ class Batches {
    * @param {object} user
    * @param {string} [queryId]
    * @param {boolean} [includeStatements]
+   * @param {number} [limit]
    */
-  async findAllForUserQuery(user, queryId = null, includeStatements = false) {
+  async findAllForUserQuery(
+    user,
+    queryId = null,
+    includeStatements = false,
+    limit = 40
+  ) {
     let batches = await this.sequelizeDb.Batches.findAll({
       where: { userId: user.id, queryId },
+      limit,
+      order: [['createdAt', 'DESC']],
     });
     batches = batches.map((item) => item.toJSON());
 
@@ -66,9 +74,8 @@ class Batches {
       });
     }
 
-    // TODO: it'd be nice if there was a small set of statement results to return here for query execution history
-    // Unsure how best to implement at this time.
-    // Would additional reads work here or should small result preview be stored on statements table?
+    // Results are in desc order, but we'll return them in ascending
+    batches = _.sortBy(batches, ['createdAt']);
 
     return batches;
   }

--- a/server/routes/batches.js
+++ b/server/routes/batches.js
@@ -1,4 +1,5 @@
 require('../typedefs');
+const moment = require('moment');
 const router = require('express').Router();
 const mustBeAuthenticated = require('../middleware/must-be-authenticated.js');
 const executeBatch = require('../lib/execute-batch');
@@ -86,6 +87,12 @@ async function list(req, res) {
   } else {
     batches = await models.batches.findAllForUser(user);
   }
+
+  batches.forEach((batch) => {
+    batch.startTimeCalendar = moment(batch.startTime).calendar();
+    batch.stopTimeCalendar = moment(batch.stopTime).calendar();
+    batch.createdAtCalendar = moment(batch.createdAt).calendar();
+  });
 
   return res.utils.data(batches);
 }

--- a/server/routes/batches.js
+++ b/server/routes/batches.js
@@ -66,8 +66,27 @@ router.post(
  * @param {Res} res
  */
 async function list(req, res) {
-  const { models, user } = req;
-  const batches = await models.batches.findAllForUser(user);
+  const { models, user, query } = req;
+  const { queryId, includeStatements } = query;
+
+  let batches;
+  if (queryId) {
+    const cleanedQueryId = queryId === 'null' ? null : queryId;
+    let cleanedIncludeStatements = false;
+    if (includeStatements) {
+      cleanedIncludeStatements =
+        includeStatements.toString().toLowerCase().trim() === 'true';
+    }
+
+    batches = await models.batches.findAllForUserQuery(
+      user,
+      cleanedQueryId,
+      cleanedIncludeStatements
+    );
+  } else {
+    batches = await models.batches.findAllForUser(user);
+  }
+
   return res.utils.data(batches);
 }
 


### PR DESCRIPTION
Adds button and side drawer to view run history for currently loaded query. If query is not  yet saved, history for "unsaved" queries is shown.

For each entry, the query run can be loaded into the editor, restoring the state of that query execution, including the results if they exist.

The design is borrowed from ideas for a flowing UI in #531, and can be thought of as an experimental trial.

![sqlpad-history-button](https://user-images.githubusercontent.com/303966/111413533-69a74980-86ac-11eb-9f8f-694b2ae080c9.jpg)

![sqlpad-history-open](https://user-images.githubusercontent.com/303966/111413534-6a3fe000-86ac-11eb-97f8-d756118c5803.jpg)


