### PR TITLE
Fix ClickHouse FORMAT JSON application and LIMIT syntax parsing

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -5582,9 +5582,9 @@
       }
     },
     "sql-limiter": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/sql-limiter/-/sql-limiter-2.4.0.tgz",
-      "integrity": "sha512-DEHp4hYCXtv/CgT6DTJVQjtBWw6xEvqRIZgcNMY9c+tQwHnVzd2zxdM1JpszbFAHB+td88QZEMEk5qL0iN7wfw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/sql-limiter/-/sql-limiter-2.5.0.tgz",
+      "integrity": "sha512-WnmkzGOg59RhDSLpON4UxWANSQWrU4Uul+34hrrdnJgFRbBGUXMciCUGyOAPCYKK2he2Jn3yTKMHEJd8PIb5vg==",
       "requires": {
         "moo": "^0.5.1"
       }

--- a/server/package.json
+++ b/server/package.json
@@ -96,7 +96,7 @@
     "snowflake-sdk": "^1.5.3",
     "socksjs": "^0.5.0",
     "sql-formatter": "^2.3.3",
-    "sql-limiter": "^2.4.0",
+    "sql-limiter": "^2.5.0",
     "sqlite3": "^5.0.0",
     "umzug": "^2.3.0",
     "uuid": "^8.3.2",


### PR DESCRIPTION
* Prevents `FORMAT JSON` from being added to `INSERT` statements
* Updates `sql-limiter` version that brings support for ClickHouse's `LIMIT <offset_number>,<limit_number>` syntax

FYI @dengc367 