### PR TITLE
fix clickhouse authentication bug in new clickhouse server: Invalid a…

### DIFF
--- a/server/drivers/clickhouse/index.js
+++ b/server/drivers/clickhouse/index.js
@@ -46,15 +46,15 @@ async function runQuery(query, connection) {
   const protocol = connection.useHTTPS ? 'https' : 'http';
   const url = `${protocol}://${connection.host}`;
   const database = connection.database;
-  const basicAuth = {
-    username: connection.username || 'default',
-    password: connection.password || '',
-  };
+
+  const username = connection.username || 'default';
+  const password = connection.password || '';
 
   const clickhouse = new ClickHouse({
     url,
     port,
-    basicAuth,
+    username,
+    password,
     format: 'json',
     config: {
       database,


### PR DESCRIPTION
…uthentication: it is not allowed to use Authorization HTTP header and authentication via parameters simultaneously.

when use `baseAuth` map option in clickhouse library, the clickhouse throws server error, comes from the clickhouse code below:

![image](https://user-images.githubusercontent.com/1353036/115982636-45099000-a5cf-11eb-848f-c6bf47104017.png)
