### PR TITLE
add https support for trino

### DIFF
--- a/server/drivers/trino/index.js
+++ b/server/drivers/trino/index.js
@@ -34,8 +34,9 @@ function runQuery(query, connection) {
   let incomplete = false;
   const rows = [];
   const port = connection.port || 8080;
+  const protocol = connection.useHTTPS ? 'https' : 'http';
   const config = {
-    url: `http://${connection.host}:${port}`,
+    url: `${protocol}://${connection.host}:${port}`,
     user: connection.username,
     catalog: connection.catalog,
     schema: connection.schema,
@@ -105,6 +106,11 @@ const fields = [
     key: 'schema',
     formType: 'TEXT',
     label: 'Schema',
+  },
+  {
+    key: 'useHTTPS',
+    formType: 'CHECKBOX',
+    label: 'Use HTTPS',
   },
 ];
 


### PR DESCRIPTION
implementation of #1017

I've built Docker image locally, run it and was able to connect to Trino running behind HTTPS. Manually tested 2 ways of configuring the connection:
* using environment variables
* in the UI