### PR TITLE
query date/datetime/timestamp columns need to setup the `dateStrings`…

### DIFF
--- a/server/drivers/mysql/index.js
+++ b/server/drivers/mysql/index.js
@@ -60,6 +60,7 @@ class Client {
       ssl: connection.mysqlSsl,
       preQueryStatements: connection.preQueryStatements,
       flags: '+INTERACTIVE',
+      dateStrings: true,
     };
 
     // TODO cache key/cert values

--- a/server/drivers/mysql2/index.js
+++ b/server/drivers/mysql2/index.js
@@ -53,6 +53,7 @@ class Client {
       timezone: 'Z',
       supportBigNumbers: true,
       flags: '+INTERACTIVE',
+      dateStrings: true,
     };
     if (connection.mysqlSsl) {
       myConfig.ssl = {};


### PR DESCRIPTION
… is `true` to solve the zero date like 0000-00-00 in mysql/mysql2 driver. 
At first, I fix the bug #1022 . If have time, it can configure this option on the connection setup form like `Idle timeout (minutes)`.