### PR TITLE
OIDC Managed Roles

### DIFF
--- a/server/routes/auth-oidc.js
+++ b/server/routes/auth-oidc.js
@@ -1,5 +1,6 @@
 require('../typedefs');
 const passport = require('passport');
+const appLog = require('../lib/app-log');
 const router = require('express').Router();
 
 /**
@@ -20,6 +21,7 @@ function handleOidcCallback(req, res, next) {
 
   function redirectUser(err, user) {
     if (err) {
+      appLog.debug(JSON.stringify(err));
       res.redirect(`${baseUrl}/signin`);
     }
     if (!user) {


### PR DESCRIPTION
This allows the roles claim to set the role of a user to `admin`. default remains `editor`.