### PR TITLE
odbc support in docker container

### DIFF
--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -1,2 +1,11 @@
-#!/bin/sh
+#!/bin/bash
+set -e
+# This iterates any sh file in the directory and executes them before our server starts
+# Note: we intentionally source the files, allowing scripts to set vars that override default behavior.
+if [ -d "/etc/docker-entrypoint.d" ]; then
+    find /etc/docker-entrypoint.d -name '*.sh' -print0 | 
+    while IFS= read -r -d '' line; do 
+        . "$line"
+    done
+fi
 exec node /usr/app/server.js $@

--- a/docker-examples/oracle-odbc-image/Dockerfile
+++ b/docker-examples/oracle-odbc-image/Dockerfile
@@ -1,0 +1,26 @@
+# Download & Unpack oracle stuff in a seperate image this reduces the amount of downloads if you change the script around
+FROM alpine:latest as oracleunpack
+RUN apk add --no-cache bash unzip wget \
+    && echo "Downloading Oracle Instant Client lite and ODBC drivers." 1>&2 \
+    && wget -q -O /opt/client.zip https://download.oracle.com/otn_software/linux/instantclient/211000/instantclient-basiclite-linux.x64-21.1.0.0.0.zip \
+    && wget -q -O /opt/odbc.zip https://download.oracle.com/otn_software/linux/instantclient/211000/instantclient-odbc-linux.x64-21.1.0.0.0.zip
+    
+RUN cd /opt \
+    && unzip -q client.zip \
+    && unzip -q odbc.zip \
+    && rm client.zip odbc.zip
+
+FROM sqlpad/sqlpad:odbc
+# Oracle instant client & odbc driver
+COPY --from=oracleunpack /opt /opt
+COPY generate-tnsnames.sh /etc/docker-entrypoint.d/generate-tnsnames.sh
+
+# Setup some oracle bullshit
+ENV TNS_ADMIN=/opt/instantclient_21_1/network/admin
+ENV LD_LIBRARY_PATH=/opt/instantclient_21_1
+# Install the driver for oracle into ODBC.
+RUN cd /opt/instantclient_21_1 && /opt/instantclient_21_1/odbc_update_ini.sh /
+
+# Testing
+ENV SQLPAD_AUTH_DISABLED=true
+ENV SQLPAD_AUTH_DISABLED_DEFAULT_ROLE=admin

--- a/docker-examples/oracle-odbc-image/generate-tnsnames.sh
+++ b/docker-examples/oracle-odbc-image/generate-tnsnames.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+# This script downloads a tnsnames.ora through env var TNS_URL
+# and iterates env vars to add to tnsnames.ora
+# You can add hosts by providing the following ENV vars.
+# (replace [X] with a number see below)
+# TNS_[X]_NAME, TNS_[X]_PORT, TNS_[X]_HOST, [TNS_[X]_SID | TNS_[X]_SERVICE_NAME]
+
+# --Example--:
+# TNS_0_NAME=testconnection
+# TNS_0_SID=mySID
+# TNS_0_HOST=some.host.example
+# 
+# TNS_1_NAME=testconnection2
+# TNS_1_SID=mySID2
+# TNS_1_HOST=some.host2.example
+
+# If a more complicated tnsnames.ora is required use the download only or overwrite this script in your own image
+
+if [ -z "$TNS_URL" ]; then
+  touch $TNS_ADMIN/tnsnames.ora
+else
+  wget -O $TNS_ADMIN/tnsnames.ora "$TNS_URL"
+fi
+
+TNS_IDX=0
+
+while true; do 
+  NAME=$(eval echo "\$TNS_${TNS_IDX}_NAME")
+  PORT=$(eval echo "\$TNS_${TNS_IDX}_PORT")
+  HOST=$(eval echo "\$TNS_${TNS_IDX}_HOST")
+  SID=$(eval echo "\$TNS_${TNS_IDX}_SID")
+  SERVICE_NAME=$(eval echo "\$TNS_${TNS_IDX}_SERVICE_NAME")
+  if [ -z "$NAME" ]; then break ; fi
+  if [ -z "$HOST" ]; then echo "Missing env var TNS_${TNS_IDX}_HOST" 1>&2 ; exit 1; fi
+  if [ -z "$SID" ] && [ -z "$SERVICE_NAME" ]; then echo "Missing env var TNS_${TNS_IDX}_SID or TNS_${TNS_IDX}_SERVICE_NAME " 1>&2 ; exit 1; fi
+
+  CONNECT_DATA=""
+  if [ -z "$SID" ]; 
+  then
+    CONNECT_DATA="SERVICE_NAME = ${SERVICE_NAME}"
+  else
+    CONNECT_DATA="SID = ${SID}"
+  fi
+  
+  echo "Adding '$NAME' to tnsnames.ora" 1>&2
+  
+  cat <<EOF >/tmp/tnsnames.tmp.entry
+$NAME =
+  (DESCRIPTION =
+    (ADDRESS = (PROTOCOL = TCP)(HOST = ${HOST})(PORT = ${PORT:-1521}))
+    (CONNECT_DATA =
+      (${CONNECT_DATA})
+    )
+  )
+EOF
+  cat $TNS_ADMIN/tnsnames.ora /tmp/tnsnames.tmp.entry > /tmp/tnsnames.new
+  cp /tmp/tnsnames.new $TNS_ADMIN/tnsnames.ora
+  TNS_IDX=$((TNS_IDX + 1))
+done
+
+rm /tmp/tnsnames.tmp.entry 2>/dev/null || true
+rm /tmp/tnsnames.new 2>/dev/null || true


### PR DESCRIPTION
This adds ODBC to the main Dockerfile where you can use `--build-arg "ODBC_ENABLED=true"` to build an image with odbc support.
This also adds support for dynamic scripts in `/etc/docker-entrypoint.d` where any sh file is executed before the main sqlpad server allowing others to inject scripts without altering sqlpad entrypoint.

Warning: This changes the base image from alpine to debian buster (node:lts-buster-slim).
This also upgrades to node to lts (node 14) (as recommended by node to use latest LTS for production or in this case the docker images)

The reason to change the base image to `lts-buster-slim` is the common incompatibility with `libc` in `alpine`. Many 3th party odbc providers only provide pre-build binaries see as an example `oracle-odbc-image` and those are generally not compatible with musl-libc. 

NOTE: Do not attempt to provide pre-build docker images for oracle or other 3th party drivers on docker hub you may end in a license hell. And the provided example for oracle is only intended as demo for the changes made to the main Dockerfile