### PR TITLE
Added fixes for OIDC illegal redirects.

### DIFF
--- a/server/routes/auth-oidc.js
+++ b/server/routes/auth-oidc.js
@@ -23,15 +23,24 @@ function handleOidcCallback(req, res, next) {
     if (err) {
       appLog.debug(JSON.stringify(err));
       res.redirect(`${baseUrl}/signin`);
+      return;
     }
     if (!user) {
       res.redirect(`${baseUrl}/signin`);
+      return;
     }
     return req.logIn(user, (err) => {
       if (err) {
         res.redirect(`${baseUrl}/signin`);
+        return;
       }
-      res.redirect(`${baseUrl}`);
+      // Redirect to an empty string is illegal.
+      // Since the baseUrl option is optional we need to check that it is having a length > 0 otherwise we can trigger an illegal redirect here.
+      if (baseUrl && baseUrl.length > 0) {
+        res.redirect(`${baseUrl}`);
+      } else {
+        res.redirect(`/`);
+      }
     });
   }
 


### PR DESCRIPTION
As commented in the code this fixes redirect issues in the OIDC login flow.

First it makes sure it does not redirect twice when error or user unavailable and does not call `logIn` in those cases anymore.

If you run sqlpad on a fqdn without a subpath (`baseUrl`) chrome and some other browsers did fail on the illegal header value for `location` header. Simply redirecting to `/`  if `baseUrl` is empty, has the desired effect of letting the user properly open sqlpad without refreshing the browser manually.

NOTE: for some unknown reason only on firefox after the illegal redirect is received it did after a few seconds do a redirect to '/'. But i could not find the origin of that redirect event (maybe firefox does this as a recovery feature for invalid response headers???).