### PR TITLE
Enhance support for Amazon Athena

### DIFF
--- a/client/src/connections/ConnectionForm.tsx
+++ b/client/src/connections/ConnectionForm.tsx
@@ -11,6 +11,7 @@ import Select from '../common/Select';
 import SpinKitCube from '../common/SpinKitCube';
 import TextArea from '../common/TextArea';
 import { api } from '../utilities/api';
+import { setAsynchronousDriver } from '../stores/editor-actions';
 
 const TEXT = 'TEXT';
 const PASSWORD = 'PASSWORD';
@@ -124,6 +125,9 @@ function ConnectionForm({ connectionId, onConnectionSaved }: any) {
     if (json.error) {
       setSaving(false);
       return message.error(json.error);
+    }
+    if (json.data) {
+      setAsynchronousDriver(json.data.isAsynchronous);
     }
     api.reloadConnections();
     return onConnectionSaved(json.data);

--- a/client/src/connections/ConnectionList.tsx
+++ b/client/src/connections/ConnectionList.tsx
@@ -4,7 +4,10 @@ import DeleteConfirmButton from '../common/DeleteConfirmButton';
 import ListItem from '../common/ListItem';
 import message from '../common/message';
 import Text from '../common/Text';
-import { selectConnectionId } from '../stores/editor-actions';
+import {
+  selectConnectionId,
+  setAsynchronousDriver,
+} from '../stores/editor-actions';
 import { api } from '../utilities/api';
 import useAppContext from '../utilities/use-app-context';
 import ConnectionEditDrawer from './ConnectionEditDrawer';
@@ -32,6 +35,7 @@ function ConnectionList() {
 
   const newConnection = () => {
     setConnectionId(null);
+    setAsynchronousDriver(false);
     setShowEdit(true);
   };
 

--- a/client/src/queryEditor/Toolbar.tsx
+++ b/client/src/queryEditor/Toolbar.tsx
@@ -5,6 +5,7 @@ import ToolbarConnectionClientButton from './ToolbarConnectionClientButton';
 import ToolbarHistoryButton from './ToolbarHistoryButton';
 import ToolbarQueryName from './ToolbarQueryName';
 import ToolbarRunButton from './ToolbarRunButton';
+import ToolbarCancelButton from './ToolbarCancelButton';
 import ToolbarSpacer from './ToolbarSpacer';
 import ToolbarToggleSchemaButton from './ToolbarToggleSchemaButton';
 
@@ -27,6 +28,8 @@ function Toolbar() {
         <ToolbarQueryName />
         <ToolbarSpacer grow />
         <ToolbarRunButton />
+        <ToolbarSpacer />
+        <ToolbarCancelButton />
         <ToolbarSpacer />
         <ToolbarHistoryButton />
         <ToolbarChartButton />

--- a/client/src/queryEditor/ToolbarCancelButton.tsx
+++ b/client/src/queryEditor/ToolbarCancelButton.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import Button from '../common/Button';
+import { connectConnectionClient, cancelQuery } from '../stores/editor-actions';
+import {
+  useExecutionStarting,
+  useSessionAsyncDriver,
+  useSessionIsRunning,
+} from '../stores/editor-store';
+
+function ToolbarCancelButton() {
+  const isStarting = useExecutionStarting();
+  const isAsynchronousDriver = useSessionAsyncDriver();
+  const isRunning = useSessionIsRunning();
+
+  if (isAsynchronousDriver) {
+    return (
+      <>
+        <Button
+          variant="primary"
+          onClick={async () => {
+            await connectConnectionClient();
+            cancelQuery();
+          }}
+          disabled={!isStarting}
+        >
+          {(isRunning && !isStarting && 'Starting') || 'Cancel'}
+        </Button>
+      </>
+    );
+  } else {
+    return <></>;
+  }
+}
+
+export default React.memo(ToolbarCancelButton);

--- a/client/src/stores/editor-store.ts
+++ b/client/src/stores/editor-store.ts
@@ -27,7 +27,9 @@ export interface EditorSession {
   batchId?: string;
   isRunning: boolean;
   isSaving: boolean;
+  isExecutionStarting: boolean;
   saveError?: string;
+  isDriverAsynchronous: boolean;
   // Editor session takes Query model fields and flattens
   queryId?: string;
   queryName: string;
@@ -72,6 +74,8 @@ export const INITIAL_SESSION: EditorSession = {
   connectionClient: undefined,
   batchId: undefined,
   isRunning: false,
+  isExecutionStarting: false,
+  isDriverAsynchronous: false,
   isSaving: false,
   saveError: undefined,
   queryId: undefined,
@@ -186,6 +190,10 @@ export function useSessionCanWrite() {
 
 export function useSessionConnectionId(): string {
   return useEditorStore((s) => s.getFocusedSession().connectionId);
+}
+
+export function useExecutionStarting(): boolean {
+  return useEditorStore((s) => s.getFocusedSession().isExecutionStarting);
 }
 
 export function useSessionConnectionClient() {
@@ -415,4 +423,8 @@ export function useStatementText(statementId?: string) {
     }
     return s.statements[statementId]?.statementText;
   });
+}
+
+export function useSessionAsyncDriver(): boolean {
+  return useEditorStore((s) => s.getFocusedSession().isDriverAsynchronous);
 }

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -9,6 +9,7 @@ export interface Connection {
   multiStatementTransactionEnabled?: boolean;
   name: string;
   supportsConnectionClient: boolean;
+  isAsynchronous: boolean;
   updatedAt: string | Date;
 }
 
@@ -46,7 +47,8 @@ export interface Statement {
   batchId: string;
   sequence: number;
   statementText: string;
-  status: 'queued' | 'started' | 'finished' | 'error';
+  status: 'queued' | 'started' | 'finished' | 'error' | 'cancelled';
+  executionId?: string;
   startTime?: string | Date;
   stopTime?: string | Date;
   durationMs?: number;
@@ -63,7 +65,7 @@ export interface Batch {
   name?: string;
   connectionId: string;
   connectionClientId: string;
-  status: 'started' | 'finished' | 'error';
+  status: 'started' | 'finished' | 'error' | 'cancelled';
   startTime: string | Date;
   stopTime: string | Date;
   durationMs: number;

--- a/client/src/utilities/api.ts
+++ b/client/src/utilities/api.ts
@@ -126,6 +126,10 @@ export const api = {
     return this.get<Batch>(`/api/batches/${batchId}`);
   },
 
+  cancelBatch(batchId: string, putData: any) {
+    return this.put(`/api/batches/${batchId}/cancel`, putData);
+  },
+
   useBatch(batchId: string) {
     return useSWR<Batch>(`/api/batches/${batchId}`);
   },

--- a/server/drivers/athena/index.js
+++ b/server/drivers/athena/index.js
@@ -1,3 +1,4 @@
+const appLog = require('../../lib/app-log');
 const AWS = require('aws-sdk');
 const athena = require('athena-express');
 const sqlLimiter = require('sql-limiter');
@@ -5,17 +6,29 @@ const { formatSchemaQueryResults } = require('../utils');
 
 const id = 'athena';
 const name = 'Athena';
+const asynchronous = true;
 
+// Not very elegant but is compatible with Athena v1 and v2
 const SCHEMA_SQL_INFORMATION_SCHEMA = `
-    SELECT c.table_schema AS table_schema,
-        c.table_name AS table_name,
-        c.column_name AS column_name,
-        c.data_type AS data_type
-    FROM information_schema.columns c
-    WHERE lower(c.table_schema) <> 'information_schema'
-    ORDER BY c.table_schema,
-        c.table_name,
-        c.ordinal_position
+
+  SELECT
+    c.table_schema as table_schema,
+    c.table_name as table_name,
+    c.column_name as column_name,
+    CASE WHEN regexp_like(c.extra_info, 'partition key')
+    THEN
+      c.data_type || ' (partitioned)'
+    ELSE
+      c.data_type
+    END as data_type
+  FROM
+    INFORMATION_SCHEMA.columns c
+  WHERE
+    c.table_schema NOT IN ('INFORMATION_SCHEMA', 'information_schema')
+  ORDER BY
+    c.table_schema,
+    c.table_name,
+    c.ordinal_position
 `;
 
 /**
@@ -23,37 +36,70 @@ const SCHEMA_SQL_INFORMATION_SCHEMA = `
  * @param {object} connection
  */
 function newAthenaClient(connection) {
-  const awsCredentials = {
-    region: connection.awsRegion,
-    accessKeyId: connection.awsAccessKeyId,
-    secretAccessKey: connection.awsSecretAccessKey,
-  };
-  AWS.config.update(awsCredentials);
+  if (connection.awsAccessKeyId && connection.awsSecretAccessKey) {
+    const awsCredentials = {
+      region: connection.awsRegion,
+      accessKeyId: connection.awsAccessKeyId,
+      secretAccessKey: connection.awsSecretAccessKey,
+    };
+    AWS.config.update(awsCredentials);
+  } else {
+    AWS.config.update({ region: connection.region });
+  }
 
   const athenaExpressConfig = {
     aws: AWS,
     s3: connection.athenaStagingDirectory,
-    workgroup: connection.athenaWorkgroup,
+    workgroup: connection.athenaWorkgroup || 'primary',
+    ignoreEmpty: false,
+    waitForResults: false,
   };
   return new athena.AthenaExpress(athenaExpressConfig);
 }
 
 /**
- * Run query for connection
- * Should return { rows, incomplete }
+ * Run query for connection and return execution ID to enable query cancellation
+ * Should return execution ID
  * @param {string} queryString
  * @param {object} connection
  */
-function runQuery(queryString, connection = {}) {
+function startQueryExecution(queryString, connection = {}) {
   const athenaClient = newAthenaClient(connection);
 
   const maxRows = connection.maxRows;
   const maxRowsPlusOne = maxRows + 1;
   const limitedQuery = sqlLimiter.limit(queryString, ['limit'], maxRowsPlusOne);
 
+  appLog.trace(limitedQuery);
   return athenaClient
     .query({ sql: limitedQuery })
     .then((results) => {
+      return results.QueryExecutionId;
+    })
+    .catch((error) => {
+      appLog.error(`Error found ${error}`);
+      throw error;
+    });
+}
+
+/**
+ * Run query for connection and return the results
+ * Should return the query results
+ * @param {string} executionId
+ * @param {object} connection
+ */
+function runQuery(executionId, connection = {}) {
+  const maxRows = connection.maxRows;
+  const maxRowsPlusOne = maxRows + 1;
+  const athenaClient = newAthenaClient(connection);
+
+  return athenaClient
+    .query(executionId)
+    .then((results) => {
+      appLog.trace(results);
+      appLog.debug(
+        `Retrieved ${results.Items.length} items out of ${results.Count}`
+      );
       let rows = results.Items;
       if (rows.length >= maxRowsPlusOne) {
         return { rows: rows.slice(0, maxRows), incomplete: true };
@@ -61,8 +107,47 @@ function runQuery(queryString, connection = {}) {
       return { rows, incomplete: false };
     })
     .catch((error) => {
+      appLog.error(`Error found ${error}`);
+      if (
+        String(error).includes('Insufficient Lake Formation permission(s) on')
+      ) {
+        throw Error(
+          "Table not found, make sure you're using a fully qualified table name, e.g. database.table"
+        );
+      }
       throw error;
     });
+}
+
+/**
+ * Cancels a query matching exeuction ID
+ * @param {string} executionId
+ * @param {*} connection
+ */
+function cancelQuery(executionId, connection = {}) {
+  if (connection.awsAccessKeyId && connection.awsSecretAccessKey) {
+    const awsCredentials = {
+      region: connection.awsRegion,
+      accessKeyId: connection.awsAccessKeyId,
+      secretAccessKey: connection.awsSecretAccessKey,
+    };
+    AWS.config.update(awsCredentials);
+  } else {
+    AWS.config.update({ region: connection.region });
+  }
+  const athena = new AWS.Athena();
+
+  const params = {
+    QueryExecutionId: executionId,
+  };
+  athena.stopQueryExecution(params, function (err) {
+    if (err) {
+      appLog.error(err);
+      throw err;
+    }
+  });
+
+  return true;
 }
 
 /**
@@ -71,7 +156,10 @@ function runQuery(queryString, connection = {}) {
  */
 function testConnection(connection) {
   const query = `SELECT 1`;
-  return runQuery(query, connection);
+  return startQueryExecution(query, connection).then((executionId) => {
+    appLog.error(executionId);
+    runQuery(executionId, connection);
+  });
 }
 
 /**
@@ -79,9 +167,9 @@ function testConnection(connection) {
  * @param {*} connection
  */
 function getSchema(connection) {
-  return runQuery(SCHEMA_SQL_INFORMATION_SCHEMA, connection).then(
-    (queryResult) => formatSchemaQueryResults(queryResult)
-  );
+  return startQueryExecution(SCHEMA_SQL_INFORMATION_SCHEMA, connection)
+    .then((executionId) => runQuery(executionId, connection))
+    .then((queryResult) => formatSchemaQueryResults(queryResult));
 }
 
 const fields = [
@@ -93,12 +181,14 @@ const fields = [
   {
     key: 'awsAccessKeyId',
     formType: 'TEXT',
-    label: 'AWS Access Key ID',
+    label:
+      'AWS Access Key ID. Leave blank if you want to use the instance profile instead',
   },
   {
     key: 'awsSecretAccessKey',
     formType: 'TEXT',
-    label: 'AWS Secret Access Key',
+    label:
+      'AWS Secret Access Key. Leave blank if you want to use the instance profile instead',
   },
   {
     key: 'athenaStagingDirectory',
@@ -108,15 +198,18 @@ const fields = [
   {
     key: 'athenaWorkgroup',
     formType: 'TEXT',
-    label: 'Athena Workgroup',
+    label: 'Athena Workgroup. Optional, defaults to "primary"',
   },
 ];
 
 module.exports = {
   id,
   name,
+  asynchronous,
   fields,
   getSchema,
   runQuery,
+  startQueryExecution,
+  cancelQuery,
   testConnection,
 };

--- a/server/drivers/validate.js
+++ b/server/drivers/validate.js
@@ -43,6 +43,10 @@ function validate(id, driver) {
   validateFunction(driver, 'runQuery');
   validateFunction(driver, 'testConnection');
   validateArray(driver, 'fields');
+
+  if (driver.asynchronous) {
+    validateFunction(driver, 'cancelQuery');
+  }
 }
 
 module.exports = validate;

--- a/server/lib/cancel-batch.js
+++ b/server/lib/cancel-batch.js
@@ -1,0 +1,100 @@
+/* eslint-disable no-await-in-loop */
+const ConnectionClient = require('./connection-client');
+const appLog = require('./app-log');
+
+/**
+ * Execute a query using batch/statement infrastructure
+ * Batch must already be created.
+ * @param {Object} config
+ * @param {import('../models/index')} models
+ * @param {import('./webhooks')} webhooks
+ * @param {string} batchId
+ */
+
+async function cancelBatch(models, webhooks, batchId) {
+  const batch = await models.batches.findOneById(batchId);
+  const user = await models.users.findOneById(batch.userId);
+  const connection = await models.connections.findOneById(batch.connectionId);
+
+  // Get existing connectionClient if one was specified to use per batch
+  // Otherwise create a new one and connect it if the ConnectionClient supports it.
+  // If a new connectionClient was created *and* connected, take note to disconnect later
+  let connectionClient;
+  let disconnectOnFinish = false;
+  if (batch.connectionClientId) {
+    connectionClient = models.connectionClients.getOneById(
+      batch.connectionClientId
+    );
+    if (!connectionClient) {
+      throw new Error('Connection client disconnected');
+    }
+  } else {
+    connectionClient = new ConnectionClient(connection, user);
+    // If connectionClient supports the "Client" driver,
+    // and it is not connected, connect it
+    if (connectionClient.Client && !connectionClient.isConnected()) {
+      await connectionClient.connect();
+      disconnectOnFinish = true;
+    }
+  }
+  // run statements
+  const batchStartTime = new Date();
+  let stopTime;
+  let statementError;
+  let statementStartTime;
+  for (const statement of batch.statements) {
+    statementStartTime = new Date();
+    try {
+      appLog.trace(
+        `Cancelling statement ${statement.executionId} by ${user.email} - ${statement.statementText}`
+      );
+
+      await connectionClient.cancelQuery(statement.executionId);
+      stopTime = new Date();
+      await models.statements.updateCancelled(statement.id, stopTime);
+      webhooks.statementCancelled(user, connection, batch, statement.id);
+    } catch (error) {
+      appLog.error(`Error found cancelling statement: ${error}`);
+      statementError = error;
+      stopTime = new Date();
+
+      await models.statements.updateErrored(
+        statement.id,
+        {
+          title: error.message,
+        },
+        stopTime,
+        stopTime - statementStartTime
+      );
+
+      const updatedBatch = await models.batches.update(batch.id, {
+        status: 'cancelled',
+        stopTime,
+        durationMs: stopTime - batchStartTime,
+      });
+
+      webhooks.statementCancelled(user, connection, updatedBatch, statement.id);
+    }
+  }
+  stopTime = new Date();
+
+  if (!statementError) {
+    await models.batches.update(batch.id, {
+      status: 'cancelled',
+      stopTime,
+      durationMs: stopTime - batchStartTime,
+    });
+  }
+
+  if (disconnectOnFinish) {
+    await connectionClient.disconnect();
+  }
+
+  const finalBatch = await models.batches.findOneById(batchId);
+  webhooks.batchFinished(user, connection, finalBatch);
+  return true;
+}
+
+module.exports = {
+  cancelBatch,
+};

--- a/server/lib/execute-batch.js
+++ b/server/lib/execute-batch.js
@@ -41,11 +41,15 @@ async function executeBatch(config, models, webhooks, batchId) {
   let stopTime;
   let queryResult;
   let statementError;
+  let statementStartTime;
   for (const statement of batch.statements) {
-    let statementStartTime = new Date();
+    statementStartTime = new Date();
+    const input = connectionClient.driver['asynchronous']
+      ? statement.executionId
+      : statement.statementText;
     try {
       await models.statements.updateStarted(statement.id, statementStartTime);
-      queryResult = await connectionClient.runQuery(statement.statementText);
+      queryResult = await connectionClient.runQuery(input);
       stopTime = new Date();
       await models.statements.updateFinished(
         statement.id,
@@ -98,4 +102,93 @@ async function executeBatch(config, models, webhooks, batchId) {
   webhooks.batchFinished(user, connection, finalBatch);
 }
 
-module.exports = executeBatch;
+/**
+ * Execute a query using batch/statement infrastructure
+ * Batch must already be created.
+ * @param {Object} config
+ * @param {import('../models/index')} models
+ * @param {import('./webhooks')} webhooks
+ * @param {string} batchId
+ */
+async function executeCancellableBatch(config, models, webhooks, batchId) {
+  const batch = await models.batches.findOneById(batchId);
+  const user = await models.users.findOneById(batch.userId);
+  const connection = await models.connections.findOneById(batch.connectionId);
+
+  // Get existing connectionClient if one was specified to use per batch
+  // Otherwise create a new one and connect it if the ConnectionClient supports it.
+  // If a new connectionClient was created *and* connected, take note to disconnect later
+  let connectionClient;
+  let disconnectOnFinish = false;
+  if (batch.connectionClientId) {
+    connectionClient = models.connectionClients.getOneById(
+      batch.connectionClientId
+    );
+    if (!connectionClient) {
+      throw new Error('Connection client disconnected');
+    }
+  } else {
+    connectionClient = new ConnectionClient(connection, user);
+    // If connectionClient supports the "Client" driver,
+    // and it is not connected, connect it
+    if (connectionClient.Client && !connectionClient.isConnected()) {
+      await connectionClient.connect();
+      disconnectOnFinish = true;
+    }
+  }
+
+  // run statements
+  const batchStartTime = new Date();
+  let executionId;
+  let statementStartTime;
+  let stopTime;
+  let statementError;
+  for (const statement of batch.statements) {
+    try {
+      statementStartTime = new Date();
+      await models.statements.updateStarted(statement.id, statementStartTime);
+      if (connectionClient.driver['asynchronous']) {
+        // Set execution ID ASAP to enable cancellation
+        executionId = await connectionClient.startQueryExecution(
+          statement.statementText
+        );
+
+        await models.statements.updateExecutionId(statement.id, executionId);
+      }
+    } catch (error) {
+      statementError = error;
+      stopTime = new Date();
+
+      await models.statements.updateErrored(
+        statement.id,
+        {
+          title: error.message,
+        },
+        stopTime,
+        stopTime - statementStartTime
+      );
+
+      const updatedBatch = await models.batches.update(batch.id, {
+        status: 'error',
+        stopTime,
+        durationMs: stopTime - batchStartTime,
+      });
+      webhooks.statementFinished(user, connection, updatedBatch, statement.id);
+      break;
+    }
+  }
+  if (statementError) {
+    await models.statements.updateErrorQueuedToCancelled(batchId);
+  }
+  if (disconnectOnFinish) {
+    await connectionClient.disconnect();
+  }
+
+  const finalBatch = await models.batches.findOneById(batchId);
+  webhooks.batchFinished(user, connection, finalBatch);
+}
+
+module.exports = {
+  executeBatch,
+  executeCancellableBatch,
+};

--- a/server/lib/webhooks.js
+++ b/server/lib/webhooks.js
@@ -203,6 +203,30 @@ class Webhooks {
       appLog.error(error, 'error sending statement created webhook');
     }
   }
+
+  async statementCancelled(user, connection, batch, statementId) {
+    const url = this.hookEnabledUrl('webhookStatementCancelledUrl');
+    if (!url) {
+      return;
+    }
+
+    try {
+      const { statements, ...batchWithoutStatements } = batch;
+
+      const statement = await this.models.statements.findOneById(statementId);
+
+      const body = {
+        statement,
+        batch: batchWithoutStatements,
+        user: userSummary(user),
+        connection: connectionSummary(connection),
+      };
+
+      return this.send('statement_cancelled', url, body);
+    } catch (error) {
+      appLog.error(error, 'error sending statement cancelled webhook');
+    }
+  }
 }
 
 module.exports = Webhooks;

--- a/server/migrations/06-00200-statement-execution-id.js
+++ b/server/migrations/06-00200-statement-execution-id.js
@@ -1,0 +1,36 @@
+const Sequelize = require('@rickbergfalk/sequelize');
+const migrationUtils = require('../lib/migration-utils');
+
+/**
+ * @param {import('sequelize').QueryInterface} queryInterface
+ * @param {import('../lib/config')} config
+ * @param {import('../lib/logger')} appLog
+ * @param {object} sequelizeDb - sequelize instance
+ */
+// eslint-disable-next-line no-unused-vars
+async function up(queryInterface, config, appLog, sequelizeDb) {
+  // Statements need to reference the remote execution to enable query cancellation
+
+  await queryInterface.addColumn('statements', 'execution_id', {
+    type: Sequelize.STRING,
+  });
+
+  await migrationUtils.addOrReplaceIndex(
+    queryInterface,
+    'statements',
+    'statements_execution_id',
+    ['execution_id'],
+    {
+      unique: true,
+      where: {
+        execution_id: {
+          [Sequelize.Op.ne]: null,
+        },
+      },
+    }
+  );
+}
+
+module.exports = {
+  up,
+};

--- a/server/models/connections.js
+++ b/server/models/connections.js
@@ -23,10 +23,12 @@ class Connections {
     const driver = drivers[connection.driver];
     if (!driver) {
       copy.supportsConnectionClient = false;
+      copy.isAsynchronous = false;
     } else {
       copy.supportsConnectionClient = Boolean(
         drivers[connection.driver].Client
       );
+      copy.isAsynchronous = Boolean(drivers[connection.driver].asynchronous);
     }
 
     // For legacy use, spread driver-field data onto connection object

--- a/server/models/statements.js
+++ b/server/models/statements.js
@@ -149,6 +149,17 @@ class Statements {
     );
   }
 
+  async updateCancelled(id, stopTime, durationMs) {
+    const update = {
+      status: 'cancelled',
+      stopTime,
+      durationMs,
+    };
+
+    await this.sequelizeDb.Statements.update(update, { where: { id } });
+    return this.findOneById(id);
+  }
+
   async updateFinished(id, queryResult, stopTime, durationMs) {
     const { config } = this;
     const dbPath = config.get('dbPath');
@@ -297,6 +308,14 @@ class Statements {
     for (const statement of statements) {
       await this.removeById(statement.id);
     }
+  }
+
+  async updateExecutionId(id, executionId) {
+    const update = {
+      executionId,
+    };
+    await this.sequelizeDb.Statements.update(update, { where: { id } });
+    return this.findOneById(id);
   }
 }
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -778,6 +778,17 @@
         }
       }
     },
+    "aws-sdk-mock": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/aws-sdk-mock/-/aws-sdk-mock-5.2.1.tgz",
+      "integrity": "sha512-dY7zA1p/lX335V4/aOJ2L8ggXC3a5zokTJFZlZVW3uU+Zej7u+V7WrEcN5TVaJAnk4auT263T6EK/OHW4WjKhw==",
+      "dev": true,
+      "dependencies": {
+        "aws-sdk": "^2.928.0",
+        "sinon": "^11.1.1",
+        "traverse": "^0.6.6"
+      }
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -2913,6 +2924,12 @@
         "debug": "4"
       }
     },
+    "just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -3478,6 +3495,12 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "lodash.includes": {
@@ -4064,6 +4087,19 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+    },
+    "nise": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.0.tgz",
+      "integrity": "sha512-W5WlHu+wvo3PaKLsJJkgPup2LrsXCcm7AWwyNZkUnn5rwPkuPBi3Iwk5SQtN0mv+K65k7nKKjwNQ30wg3wLAQQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^7.0.4",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
     },
     "node-addon-api": {
       "version": "1.7.2",
@@ -5664,6 +5700,55 @@
         "is-arrayish": "^0.3.1"
       }
     },
+    "sinon": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.1.tgz",
+      "integrity": "sha512-ZSSmlkSyhUWbkF01Z9tEbxZLF/5tRC9eojCdFh33gtQaP7ITQVaMWQHGuFM7Cuf/KEfihuh1tTl3/ABju3AQMg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": "^7.1.0",
+        "@sinonjs/samsam": "^6.0.2",
+        "diff": "^5.0.0",
+        "nise": "^5.1.0",
+        "supports-color": "^7.2.0"
+      }
+    },
+    "@sinonjs/commons": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
+      "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.0.2.tgz",
+      "integrity": "sha512-jxPRPp9n93ci7b8hMfJOFDPRLFYadN6FSpeROFTR4UNF4i5b+EK6m4QXPO46BDhFgRy1JuS87zAnFOzCUwMJcQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "slice-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
@@ -6336,6 +6421,11 @@
         }
       }
     },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
+    },
     "triple-beam": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
@@ -6397,6 +6487,12 @@
       "requires": {
         "prelude-ls": "^1.2.1"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.20.2",

--- a/server/package.json
+++ b/server/package.json
@@ -42,8 +42,8 @@
   "dependencies": {
     "@google-cloud/bigquery": "^5.6.0",
     "@rickbergfalk/sequelize": "^6.6.5",
-    "aws-sdk": "^2.955.0",
     "athena-express": "^7.1.0",
+    "aws-sdk": "^2.955.0",
     "bcryptjs": "^2.4.3",
     "body-parser": "^1.19.0",
     "cassandra-driver": "^4.6.3",
@@ -114,6 +114,7 @@
     "odbc": "^2.2.2"
   },
   "devDependencies": {
+    "aws-sdk-mock": "^5.2.1",
     "bytes": "3.1.0",
     "eslint": "^7.28.0",
     "eslint-config-airbnb-base": "^14.2.1",
@@ -122,9 +123,12 @@
     "eslint-plugin-prettier": "^3.4.0",
     "mocha": "^9.0.0",
     "ncp": "^2.0.0",
+    "nise": "^5.1.0",
     "node-dev": "^7.0.0",
     "parse-link-header": "^1.0.1",
     "pino-pretty": "^5.0.2",
-    "supertest": "^6.1.1"
+    "sinon": "^11.1.1",
+    "supertest": "^6.1.1",
+    "traverse": "^0.6.6"
   }
 }

--- a/server/sequelize-db/batches.js
+++ b/server/sequelize-db/batches.js
@@ -29,7 +29,7 @@ module.exports = function (sequelize) {
           // Potentially add 'cancelled'?
           // We have no way of canceling current statement but future could be
           // If a batch errors, any statements following error will be "cancelled" status
-          isIn: [['started', 'finished', 'error']],
+          isIn: [['started', 'finished', 'error', 'cancelled']],
         },
         defaultValue: 'started',
       },

--- a/server/sequelize-db/statements.js
+++ b/server/sequelize-db/statements.js
@@ -63,6 +63,9 @@ module.exports = function (sequelize) {
         type: Sequelize.DATE,
         allowNull: false,
       },
+      executionId: {
+        type: Sequelize.STRING,
+      },
     },
     {
       tableName: 'statements',

--- a/server/test/api/batches.js
+++ b/server/test/api/batches.js
@@ -6,6 +6,9 @@ const util = require('util');
 const path = require('path');
 const TestUtils = require('../utils');
 const access = util.promisify(fs.access);
+const { v4: uuidv4 } = require('uuid');
+const AWSMock = require('aws-sdk-mock');
+const AWS = require('aws-sdk');
 
 const query1 = `SELECT 1 AS id, 'blue' AS color`;
 const query2 = `SELECT 1 AS id, 'blue' AS color UNION ALL SELECT 2 AS id, 'red' AS color ORDER BY id`;
@@ -16,13 +19,41 @@ function wait(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function setupAthenaMock() {
+  AWSMock.setSDKInstance(AWS);
+
+  AWSMock.mock('Athena', 'startQueryExecution', () => {
+    return Promise.resolve({ QueryExecutionId: uuidv4() });
+  });
+  AWSMock.mock('Athena', 'stopQueryExecution', () => {
+    return Promise.resolve({});
+  });
+  AWSMock.mock('Athena', 'getQueryResults', () => {
+    return Promise.resolve({ results: [] });
+  });
+  AWSMock.mock('Athena', 'getQueryExecution', () => {
+    return Promise.resolve({
+      QueryExecution: {
+        Status: { State: 'SUCCEEDED' },
+        ResultConfiguration: { OutputLocation: 's3://test/location/data.csv' },
+        StatementType: 'DML',
+      },
+    });
+  });
+  AWSMock.mock('S3', 'getObject', () => {
+    return Promise.resolve({});
+  });
+}
+
 describe('api/batches', function () {
   /**
    * @type {TestUtils}
    */
   let utils;
   let query;
+  let asyncQuery;
   let connection;
+  let asyncDriverConnection;
   let batch;
   let batchWithoutQueryId;
   let statement1;
@@ -45,11 +76,23 @@ describe('api/batches', function () {
     });
     await utils.init(true);
 
+    setupAthenaMock();
+
     connection = await utils.post('admin', '/api/connections', {
       name: 'test connection',
       driver: 'sqlite',
       data: {
         filename: './test/fixtures/sales.sqlite',
+      },
+    });
+
+    asyncDriverConnection = await utils.post('admin', '/api/connections', {
+      driver: 'athena',
+      name: 'test async driver connection',
+      data: {
+        awsRegion: 'us-east-1',
+        awsAccessKeyId: 'access',
+        awsSecretAccessKey: 'secret',
       },
     });
 
@@ -59,6 +102,18 @@ describe('api/batches', function () {
       connectionId: connection.id,
       queryText,
     });
+
+    asyncQuery = await utils.post('admin', '/api/queries', {
+      name: 'test async connection query',
+      tags: ['test'],
+      connectionId: asyncDriverConnection.id,
+      queryText,
+    });
+  });
+
+  after(async function () {
+    // Bring back the library to avoid hiding issues by inadvertently mocking
+    AWSMock.restore();
   });
 
   it('Creates batch', async function () {
@@ -374,5 +429,51 @@ describe('api/batches', function () {
       },
       413
     );
+  });
+
+  it('creates batch and cancels it', async function () {
+    batch = await utils.post('admin', `/api/batches`, {
+      connectionId: asyncDriverConnection.id,
+      queryId: asyncQuery.id,
+      batchText: queryText,
+      selectedText: queryText,
+    });
+    assert(batch.id);
+    const response = await utils.put(
+      'admin',
+      `/api/batches/${batch.id}/cancel`,
+      {
+        connectionId: asyncDriverConnection.id,
+      }
+    );
+    assert(response);
+    assert.equal(response.status, 'cancelled');
+    assert(response.statements);
+    assert.equal(response.statements.length, 2);
+    for (let s in response.statement) {
+      if (s.hasOwnProperty('status')) {
+        assert.equal(s.status, 'cancelled');
+      } else {
+        assert.fail('statement without status');
+      }
+    }
+  });
+
+  it('creates batch, tries to cancel it, and receives 400 when unsupported', async function () {
+    batch = await utils.post('admin', `/api/batches`, {
+      connectionId: connection.id,
+      batchText: queryText,
+      selectedText: queryText,
+    });
+    assert(batch.id);
+    const response = await utils.put(
+      'admin',
+      `/api/batches/${batch.id}/cancel`,
+      {
+        connectionId: connection.id,
+      },
+      400
+    );
+    assert(response);
   });
 });

--- a/server/test/api/test-connection.js
+++ b/server/test/api/test-connection.js
@@ -1,10 +1,17 @@
 const TestUtils = require('../utils');
+const AWSMock = require('aws-sdk-mock');
+const AWS = require('aws-sdk');
 
 describe('api/test-connection', function () {
   const utils = new TestUtils();
 
   before(function () {
     return utils.init(true);
+  });
+
+  after(function () {
+    // Prevent unadvertent mocking
+    AWSMock.restore();
   });
 
   it('tests connection success', async function () {
@@ -25,6 +32,45 @@ describe('api/test-connection', function () {
         filename: './test/fixtures/not-real-db',
       },
       500
+    );
+  });
+
+  it('tests connection success for async connections', async function () {
+    AWSMock.setSDKInstance(AWS);
+
+    AWSMock.mock('Athena', 'startQueryExecution', () => {
+      return Promise.resolve({
+        QueryExecutionId: '123e4567-e89b-12d3-a456-426614174000',
+      });
+    });
+    AWSMock.mock('Athena', 'getQueryResults', () => {
+      return Promise.resolve({ results: [] });
+    });
+    AWSMock.mock('Athena', 'getQueryExecution', () => {
+      return Promise.resolve({
+        QueryExecution: {
+          Status: { State: 'SUCCEEDED' },
+          ResultConfiguration: {
+            OutputLocation: 's3://test/location/data.csv',
+          },
+          StatementType: 'DML',
+        },
+      });
+    });
+    AWSMock.mock('S3', 'getObject', () => {
+      return Promise.resolve({});
+    });
+    await utils.post(
+      'admin',
+      '/api/test-connection',
+      {
+        name: 'test async connection',
+        driver: 'athena',
+        awsRegion: 'us-east-1',
+        awsAccessKeyId: 'access',
+        awsSecretAccessKey: 'secret',
+      },
+      200
     );
   });
 });

--- a/server/test/lib/connection-clients.js
+++ b/server/test/lib/connection-clients.js
@@ -2,6 +2,9 @@ const assert = require('assert').strict;
 const path = require('path');
 const TestUtils = require('../utils');
 const ConnectionClient = require('../../lib/connection-client');
+const { v4: uuidv4 } = require('uuid');
+const AWSMock = require('aws-sdk-mock');
+const AWS = require('aws-sdk');
 
 function wait(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -10,9 +13,12 @@ function wait(ms) {
 describe('lib/connection-clients', function () {
   const utils = new TestUtils();
   let connection1;
+  let connection2;
 
   before(async function () {
     await utils.init(true);
+
+    AWSMock.setSDKInstance(AWS);
 
     connection1 = await utils.post('admin', '/api/connections', {
       driver: 'sqlite',
@@ -26,6 +32,18 @@ describe('lib/connection-clients', function () {
       idleTimeoutSeconds: 1,
       multiStatementTransactionEnabled: true,
     });
+    connection2 = await utils.post('admin', '/api/connections', {
+      driver: 'athena',
+      name: 'async-connection-client-test',
+      data: {
+        awsRegion: 'us-east-1',
+      },
+    });
+  });
+
+  afterEach(async function () {
+    // Prevent unadvertently mocking
+    AWSMock.restore();
   });
 
   it('Keep-alive keeps it alive', async function () {
@@ -105,5 +123,58 @@ describe('lib/connection-clients', function () {
     await wait(300);
     connectionClient.keepAlive();
     assert(!connectionClient.isConnected());
+  });
+
+  it('Throws an error when starting an async query with unsupported driver', async function () {
+    const connectionClient = new ConnectionClient(
+      connection1,
+      utils.users.admin
+    );
+    await assert.rejects(
+      connectionClient.startQueryExecution({}),
+      new Error('Driver SQLite does not support async queries')
+    );
+  });
+
+  it('Succeeds starting an async query with a supported driver', async function () {
+    const connectionClient = new ConnectionClient(
+      connection2,
+      utils.users.admin
+    );
+    const uuid = uuidv4();
+
+    AWSMock.mock('Athena', 'startQueryExecution', () => {
+      return Promise.resolve({ QueryExecutionId: uuid });
+    });
+
+    const executionId = await connectionClient.startQueryExecution('SELECT 1');
+    assert(executionId);
+    assert.equal(executionId, uuid);
+  });
+
+  it('Throws an error when cancelling an async query with unsupported driver', async function () {
+    const connectionClient = new ConnectionClient(
+      connection1,
+      utils.users.admin
+    );
+
+    await assert.rejects(
+      connectionClient.cancelQuery(uuidv4()),
+      new Error('Driver SQLite does not support cancellation of queries')
+    );
+  });
+
+  it('Succeeds cancelling an async query with a supported driver', async function () {
+    const connectionClient = new ConnectionClient(
+      connection2,
+      utils.users.admin
+    );
+
+    AWSMock.mock('Athena', 'stopQueryExecution', () => {
+      return Promise.resolve({});
+    });
+    const output = await connectionClient.cancelQuery(uuidv4());
+    assert(output);
+    assert.equal(output, true);
   });
 });


### PR DESCRIPTION
This change extends the driver data model to include a flag indicating
that the driver implements a method to cancel queries.
The client renders a "cancel query" button, disabled when the query is
not running, if the driver has this flag set. Cancellation is important
to minimize costs for queries that were issued by mistake

It extends the schema query to show a "partition" hint next to the data
type of the column. The query is compatible with Athena engine v1 and
v2. This is important as it hints users which columns to include in
their queries to minimize the amount of data scanned (i.e. predicate
pushdown)

Resolves #1008