### PR TITLE
fix: Prevent disclosure of Google OAuth Secret key

### DIFF
--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -117,7 +117,7 @@ export interface AppInfo {
     baseUrl: string;
     defaultConnectionId: string;
     editorWordWrap: boolean;
-    googleAuthConfigured: string;
+    googleAuthConfigured: boolean;
     ldapConfigured: boolean;
     ldapRolesConfigured: boolean;
     localAuthConfigured: boolean;

--- a/server/routes/app.js
+++ b/server/routes/app.js
@@ -28,7 +28,7 @@ async function getApp(req, res) {
       baseUrl: config.get('baseUrl'),
       defaultConnectionId: config.get('defaultConnectionId'),
       editorWordWrap: config.get('editorWordWrap'),
-      googleAuthConfigured: config.googleAuthConfigured(),
+      googleAuthConfigured: Boolean(config.googleAuthConfigured()),
       localAuthConfigured: !config.get('userpassAuthDisabled'),
       publicUrl: config.get('publicUrl'),
       samlConfigured: Boolean(config.get('samlEntryPoint')),


### PR DESCRIPTION
`/api/app` endpoint discloses the value of the `SQLPAD_GOOGLE_CLIENT_SECRET` config variable, and the App endpoint is also accessible to unauthenticated users. Ideally, OAuth Client Secret should not be disclosed publicly (Ref: https://datatracker.ietf.org/doc/html/rfc6819#page-16). 

This PR converts the config value to boolean to prevent inadvertent disclosure.
