### PR TITLE
Made migrations MySQL 5.7 safe

### DIFF
--- a/server/migrations/04-00400-query-history-to-batch.js
+++ b/server/migrations/04-00400-query-history-to-batch.js
@@ -18,47 +18,43 @@ async function up(queryInterface, config, appLog, sequelizeDb) {
     castType = 'UNSIGNED';
   }
 
-  [
-    `
-      CREATE VIEW statement_summary AS (
-        SELECT 
-          batch_id,
-          SUM(row_count) AS row_count,
-          MAX(CAST(incomplete AS ${castType})) AS incomplete
-        FROM
-          statements
-        GROUP BY
-          batch_id
-      )
-    ;`,
+  await sequelizeDb.query(
     `
       CREATE VIEW vw_query_history AS
-        SELECT
-          b.id,
-          b.query_id,
-          b.name AS query_name,
-          b.connection_id,
-          c.name AS connection_name,
-          b.status,
-          b.start_time,
-          b.stop_time,
-          b.duration_ms,
-          b.selected_text AS query_text,
-          b.user_id,
-          u.email AS user_email,
-          ss.row_count,
-          ss.incomplete
-        FROM 
-          batches b
-          LEFT JOIN users u ON b.user_id = u.id
-          LEFT JOIN connections c ON b.connection_id = c.id
-          LEFT JOIN statement_summary ss ON b.id = ss.batch_id
-    ;`,
-  ].forEach(async (query) => {
-    await sequelizeDb.query(query, {
+      SELECT
+        b.id,
+        b.query_id,
+        b.name AS query_name,
+        b.connection_id,
+        c.name AS connection_name,
+        b.status,
+        b.start_time,
+        b.stop_time,
+        b.duration_ms,
+        b.selected_text AS query_text,
+        b.user_id,
+        u.email AS user_email,
+        ss.row_count,
+        ss.incomplete
+      FROM
+        batches b
+        LEFT JOIN users u ON b.user_id = u.id
+        LEFT JOIN connections c ON b.connection_id = c.id
+        LEFT JOIN (
+          SELECT
+            batch_id,
+            SUM(row_count) AS row_count,
+            MAX(CAST(incomplete AS ${castType})) AS incomplete
+          FROM
+            statements
+          GROUP BY
+            batch_id
+        ) ss ON b.id = ss.batch_id
+    `,
+    {
       type: Sequelize.QueryTypes.RAW,
-    });
-  });
+    }
+  );
 }
 
 module.exports = {

--- a/server/migrations/06-00010-fix-query-history-view.js
+++ b/server/migrations/06-00010-fix-query-history-view.js
@@ -29,50 +29,46 @@ async function up(queryInterface, config, appLog, sequelizeDb) {
     castType = 'UNSIGNED';
   }
 
-  [
-    `
-      CREATE VIEW statement_summary AS (
-        SELECT
-          batch_id,
-          SUM(row_count) AS row_count,
-          MAX(CAST(incomplete AS ${castType})) AS incomplete
-        FROM
-          statements
-        GROUP BY
-          batch_id
-      )
-    ;`,
+  await sequelizeDb.query(
     `
       CREATE VIEW vw_query_history AS
-        SELECT
-          b.id,
-          b.query_id,
-          b.name AS query_name,
-          b.connection_id,
-          c.name AS connection_name,
-          b.status,
-          b.start_time,
-          b.stop_time,
-          b.duration_ms,
-          CASE 
-            WHEN b.selected_text = '' OR b.selected_text IS NULL THEN b.batch_text 
-            ELSE b.selected_text 
-            END AS query_text,
-          b.user_id,
-          u.email AS user_email,
-          ss.row_count,
-          ss.incomplete
-        FROM 
-          batches b
-          LEFT JOIN users u ON b.user_id = u.id
-          LEFT JOIN connections c ON b.connection_id = c.id
-          LEFT JOIN statement_summary ss ON b.id = ss.batch_id
-    ;`,
-  ].forEach(async (query) => {
-    await sequelizeDb.query(query, {
+      SELECT
+        b.id,
+        b.query_id,
+        b.name AS query_name,
+        b.connection_id,
+        c.name AS connection_name,
+        b.status,
+        b.start_time,
+        b.stop_time,
+        b.duration_ms,
+        CASE
+          WHEN b.selected_text = '' OR b.selected_text IS NULL THEN b.batch_text
+          ELSE b.selected_text
+          END AS query_text,
+        b.user_id,
+        u.email AS user_email,
+        ss.row_count,
+        ss.incomplete
+      FROM
+        batches b
+        LEFT JOIN users u ON b.user_id = u.id
+        LEFT JOIN connections c ON b.connection_id = c.id
+        LEFT JOIN (
+          SELECT
+            batch_id,
+            SUM(row_count) AS row_count,
+            MAX(CAST(incomplete AS ${castType})) AS incomplete
+          FROM
+            statements
+          GROUP BY
+            batch_id
+        ) ss ON b.id = ss.batch_id
+    `,
+    {
       type: Sequelize.QueryTypes.RAW,
-    });
-  });
+    }
+  );
 }
 
 module.exports = {

--- a/server/migrations/06-00010-fix-query-history-view.js
+++ b/server/migrations/06-00010-fix-query-history-view.js
@@ -29,20 +29,22 @@ async function up(queryInterface, config, appLog, sequelizeDb) {
     castType = 'UNSIGNED';
   }
 
-  await sequelizeDb.query(
+  [
     `
-      CREATE VIEW vw_query_history AS 
-        WITH statement_summary AS (
-          SELECT 
-            batch_id, 
-            SUM(row_count) AS row_count, 
-            MAX(CAST(incomplete AS ${castType})) AS incomplete
-          FROM 
-            statements
-          GROUP BY 
-            batch_id
-        )
-        SELECT 
+      CREATE VIEW statement_summary AS (
+        SELECT
+          batch_id,
+          SUM(row_count) AS row_count,
+          MAX(CAST(incomplete AS ${castType})) AS incomplete
+        FROM
+          statements
+        GROUP BY
+          batch_id
+      )
+    ;`,
+    `
+      CREATE VIEW vw_query_history AS
+        SELECT
           b.id,
           b.query_id,
           b.name AS query_name,
@@ -65,11 +67,12 @@ async function up(queryInterface, config, appLog, sequelizeDb) {
           LEFT JOIN users u ON b.user_id = u.id
           LEFT JOIN connections c ON b.connection_id = c.id
           LEFT JOIN statement_summary ss ON b.id = ss.batch_id
-    `,
-    {
+    ;`,
+  ].forEach(async (query) => {
+    await sequelizeDb.query(query, {
       type: Sequelize.QueryTypes.RAW,
-    }
-  );
+    });
+  });
 }
 
 module.exports = {


### PR DESCRIPTION
In two migration queries, the following part of the statement didn't play well with MySQL:

```
WITH statement_summary AS ( ...
```

This pull request breaks such nested queries into atomic statements. Alternatively, I'd also tried using `dialectOptions: { multipleStatements: true }` for Sequelize, but that was causing the test setup to fail 🤷.

**Edit (09-09-2021)**
_This is being done specifically for MySQL 5.7 compatibility_