### PR TITLE
SAML based role management

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -202,6 +202,14 @@ SQLPAD_SAML_AUTO_SIGN_UP = "false"
 # Accepted values are `editor` and `admin`.
 SQLPAD_SAML_DEFAULT_ROLE = "editor"
 
+# If set to true on each login the role is set based on the rules below.
+# It is recommended to set this to true, if you use one of the supported SAML claims to manage access.
+SQLPAD_SAML_ENFORCED_ROLE = "false"
+
+# The AzureAD group to assign to admin role.
+# Note: this does not need to be a UUID, it depends on how the claim is setup in Azure but the default is a UUID.
+SQLPAD_SAML_ADMIN_GROUP = '00000000-0000-0000-0000-000000000000'
+
 # Public URL required
 PUBLIC_URL = "http://localhost"
 
@@ -210,6 +218,17 @@ SQLPAD_USERPASS_AUTH_DISABLED = true
 ```
 
 SQLPad users do not need to be added ahead of time, and may be created on the fly using `SQLPAD_SAML_AUTO_SIGN_UP`. Whenever a new user is detected (unable to match to existing user email), a user record will be added to SQLPad's user table and a user signed in. By default users are not auto-created and must otherwise be added ahead of time.
+
+Supported SAML claims: 
+- Azure `role` also known as `appRoles` in azure
+- Azure `groups`
+
+Order for determining the SAML role:
+1. Is role `admin` present in role claim? if yes, then sqlpad role is `admin`.
+2. Is `SQLPAD_SAML_ADMIN_GROUP` present in groups claim? if yes, then sqlpad role is `admin`
+3. SQLPad role is `SQLPAD_SAML_DEFAULT_ROLE`
+
+The SAML base roles selection is used only when `SQLPAD_SAML_ENFORCED_ROLE` is `true` on each login, or when creating a new user.
 
 ## LDAP
 

--- a/server/auth-strategies/saml.js
+++ b/server/auth-strategies/saml.js
@@ -3,6 +3,84 @@ const SamlStrategy = require('passport-saml').Strategy;
 const appLog = require('../lib/app-log');
 
 /**
+ * Lookup table to make code below more readable.
+ * For AzureAD claims see, https://docs.microsoft.com/nl-nl/azure/active-directory/develop/reference-saml-tokens
+ */
+const CLAIMS = {
+  emailaddress:
+    'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress',
+  family_name: 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname',
+  given_name: 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname',
+  display_name: 'http://schemas.microsoft.com/identity/claims/displayname',
+  role: 'http://schemas.microsoft.com/ws/2008/06/identity/claims/role',
+  groups: 'http://schemas.microsoft.com/ws/2008/06/identity/claims/groups',
+};
+
+/**
+ * This should ne widely accaptable.
+ * @param {import('passport-saml').Profile} p
+ */
+function getSamlName(p) {
+  // azure...
+  if (CLAIMS.display_name in p) return p[CLAIMS.display_name];
+
+  // The two below are not always available so lets hope display_name captures that.
+  /** @type string | undefined */
+  const family_name = p[CLAIMS.family_name];
+  /** @type string | undefined */
+  const given_name = p[CLAIMS.given_name];
+
+  if (family_name && given_name) {
+    return `${given_name} ${family_name}`;
+  }
+
+  return undefined;
+}
+
+/**
+ * Use claims to determine the role of the user instead of having it managed in SQLPad.
+ *
+ * @param {import('passport-saml').Profile} p
+ */
+function isAdmin(p, samlAdminGroup) {
+  // The saml api only gives an array if more then one value for an attribute is given otherwise a plain string.
+
+  /**
+   * This one is AzureAD specific, and emulates the OIDC roles structure in SAML.
+   *
+   * @type string[] | undefined
+   */
+  const appRoles = p[CLAIMS.role];
+  if (appRoles) {
+    // So in case multiple roles are send.
+    if (Array.isArray(appRoles) && appRoles.include('admin')) return true;
+    else if (appRoles === 'admin') return true;
+  }
+
+  /** In AzureAd this may need to be enabled explicitly */
+  if (samlAdminGroup && samlAdminGroup.length > 0) {
+    /**
+     * This one is AzureAD specific, but allows you to specify access based on a AD group.
+     * NOTE: it is almost always a UUID, but it can be remapped to a group attribute in AzureAD.
+     * @type string[] | undefined
+     */
+    const userGroups = p[CLAIMS.groups];
+    if (userGroups) {
+      if (Array.isArray(userGroups) && userGroups.includes(samlAdminGroup))
+        return true;
+      else if (userGroups === samlAdminGroup) return true;
+    }
+  }
+
+  return false;
+}
+
+function getSamlRole(p, samlAdminGroup, samlDefaultRole) {
+  if (isAdmin(p, samlAdminGroup)) return 'admin';
+  return samlDefaultRole;
+}
+
+/**
  * Adds passport SAML strategy if SAML is configured
  * @param {object} config
  */
@@ -10,7 +88,29 @@ function enableSaml(config) {
   if (config.samlAuthConfigured()) {
     appLog.info('Enabling SAML authentication strategy.');
 
+    const samlEnforcedRole =
+      config.get('samlEnforcedRole') === 'true' ||
+      config.get('samlEnforcedRole') === true;
+
+    /**
+     * @type string
+     */
+    const samlAdminGroup = config.get('samlAdminGroup');
+
+    /**
+     * It is best to keep this 'editor' and use claims to manage admin role for SQLPAD.
+     * @type string
+     */
+    const samlDefaultRole = config.get('samlDefaultRole');
+
+    // FIX: https://github.com/node-saml/passport-saml/blob/v3.1.2/src/node-saml/types.ts#L101
+    let samlAuthContext = config.get('samlAuthContext');
+    if (samlAuthContext && !Array.isArray(samlAuthContext)) {
+      samlAuthContext = [samlAuthContext];
+    }
+
     passport.use(
+      'saml',
       new SamlStrategy(
         {
           passReqToCallback: true,
@@ -19,41 +119,55 @@ function enableSaml(config) {
           issuer: config.get('samlIssuer'),
           callbackUrl: config.get('samlCallbackUrl'),
           cert: config.get('samlCert'),
-          authnContext: config.get('samlAuthContext'),
+          authnContext: samlAuthContext,
           identifierFormat: null,
         },
         async function (req, p, done) {
-          const email =
-            p[
-              'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress'
-            ];
-
+          const email = p[CLAIMS.emailaddress];
           // If email is not provided - no auth
           if (!email) {
             return done(null, false);
           }
-          appLog.info('User attempts log in via SAML %s', email);
+
+          const name = getSamlName(p);
 
           const { models, webhooks } = req;
 
           let user = await models.users.findOneByEmail(email);
 
+          /** @type string */
+          const samlAssignedRole = getSamlRole(
+            p,
+            samlAdminGroup,
+            samlDefaultRole
+          );
+
           if (user) {
             if (user.disabled) {
               return done(null, false);
             }
-            return done(null, {
-              id: user.id,
-              role: user.role,
-              email: user.email,
-            });
+            if (samlEnforcedRole && user.role !== samlAssignedRole) {
+              appLog.debug(
+                `User '${email}' role changed to '${samlAssignedRole}' based on SAML attributes`
+              );
+              user = await models.users.update(user.id, {
+                name,
+                role: samlAssignedRole,
+                signupAt: new Date(),
+              });
+            }
+            return done(null, user);
           }
 
           // If auto sign up is turned on create user
           if (config.get('samlAutoSignUp')) {
+            appLog.debug(
+              `User '${email}' created with role '${samlAssignedRole}' based on SAML attributes`
+            );
             const newUser = await models.users.create({
+              name,
               email,
-              role: config.get('samlDefaultRole'),
+              role: samlAssignedRole,
               signupAt: new Date(),
             });
             webhooks.userCreated(newUser);

--- a/server/lib/config/config-items.js
+++ b/server/lib/config/config-items.js
@@ -255,6 +255,16 @@ const configItems = [
     default: 'editor',
   },
   {
+    key: 'samlAdminGroup',
+    envVar: 'SQLPAD_SAML_ADMIN_GROUP',
+    default: '',
+  },
+  {
+    key: 'samlEnforcedRole',
+    envVar: 'SQLPAD_SAML_ENFORCED_ROLE',
+    default: false,
+  },
+  {
     key: 'allowConnectionAccessToEveryone',
     envVar: 'SQLPAD_ALLOW_CONNECTION_ACCESS_TO_EVERYONE',
     default: true,


### PR DESCRIPTION
This allows SAML to handle role management of users in SQLPad.

It uses SAML claims to determine if the user is allowed to be admin.

To not break compatibility `SQLPAD_SAML_ENFORCED_ROLE` must be set to true if you want to use it on each login see `docs/authentication.md` for details.

It also fixes a bug with `samlAuthContext` that was probably caused by a package update.

Most of this is very specific to Azure but should allow other providers to be added with relative ease now.


