### PR TITLE
Limit listed connection based on user access.

### DIFF
--- a/server/models/connection-accesses.js
+++ b/server/models/connection-accesses.js
@@ -85,6 +85,15 @@ class ConnectionAccesses {
     return this.sequelizeDb.ConnectionAccesses.findOne({ where });
   }
 
+  findAllActiveByUserId(userId) {
+    const where = {
+      userId: { [Op.in]: [userId, consts.EVERYONE_ID] },
+      expiryDate: { [Op.gt]: new Date() },
+    };
+
+    return this.sequelizeDb.ConnectionAccesses.findAll({ where });
+  }
+
   findAllActiveByConnectionId(connectionId) {
     const where = {
       connectionId: { [Op.in]: [connectionId, consts.EVERY_CONNECTION_ID] },


### PR DESCRIPTION
The current UI pulls all connections regardless of access this changes that by only returning connections that the user has access to.
Condition to get connections.
- user has role admin, no access checks are executed and you get all connections.
- user must have a connection exposed through access menu by an admin.
  - The user access list is retrieved by using the current `user.id` or the magic `consts.EVERYONE_ID`.
  - If the user's access list contains `consts.EVERY_CONNECTION_ID` all connections are returned.
  - Otherwise the `connection.id` must be contained in the user access list

