### PR TITLE
Allow setting session cookie SameSite.

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -149,6 +149,10 @@ SQLPAD_OIDC_ISSUER = "https://some.openidprovider.com/oauth2/default"
 SQLPAD_OIDC_AUTHORIZATION_URL = "https://some.openidprovider.com/oauth2/default/v1/authorize"
 SQLPAD_OIDC_TOKEN_URL = "https://some.openidprovider.com/oauth2/default/v1/token"
 SQLPAD_OIDC_USER_INFO_URL = "https://some.openidprovider.okta.com/oauth2/default/v1/userinfo"
+
+# To enable spec compliant browsers to work.
+# Default is 'strict' and that removes the session cookie on redirects.
+SQLPAD_SESSION_COOKIE_SAME_SITE = 'Lax'
 ```
 
 The callback redirect URI used by SQLPad is `<baseurl>/auth/oidc/callback`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,6 +62,11 @@ SQLPAD_SESSION_MINUTES = 60
 # `database` will use whatever backend database is used (or SQLite if SQLPAD_DB_PATH is set)
 SQLPAD_SESSION_STORE = "file"
 
+# The the SameSite restriction for the Session cookie
+# You may need to switch this to 'Lax' for proper login routing in browsers e.g. oidc does not work in firefox with 'strict'.
+# any login routing dependent on redirects requires 'Lax' to work for more info read https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+SQLPAD_SESSION_COOKIE_SAME_SITE = 'strict'
+
 # Similar to session storage, query result storage may also be configured.
 # Valid values are `file` (default), `database`, `redis`, `memory`
 # If set to `memory`, store is limited to 1000 entries with a max age of 1 hour

--- a/server/app.js
+++ b/server/app.js
@@ -109,12 +109,13 @@ async function makeApp(config, models) {
   );
 
   const cookieMaxAgeMs = parseInt(config.get('sessionMinutes'), 10) * 60 * 1000;
+  const cookieSameSite = config.get('sessionCookieSameSite');
 
   const sessionOptions = {
     saveUninitialized: false,
     resave: true,
     rolling: true,
-    cookie: { maxAge: cookieMaxAgeMs, sameSite: 'strict' },
+    cookie: { maxAge: cookieMaxAgeMs, sameSite: cookieSameSite },
     secret: config.get('cookieSecret'),
     name: config.get('cookieName'),
   };

--- a/server/lib/config/config-items.js
+++ b/server/lib/config/config-items.js
@@ -30,6 +30,11 @@ const configItems = [
     default: 60,
   },
   {
+    key: 'sessionCookieSameSite',
+    envVar: 'SQLPAD_SESSION_COOKIE_SAME_SITE',
+    default: 'strict',
+  },
+  {
     key: 'sessionStore',
     envVar: 'SQLPAD_SESSION_STORE',
     default: 'file', // database, redis, memory


### PR DESCRIPTION
This will allow people to fix issues with login routing that is dependent on sessions and redirects. e.g. firefox with oidc. Chrome apparently is not following 'strict' mode to the letter. 