### PR TITLE
Allow base64 for mysql ssl

### DIFF
--- a/server/drivers/mysql/index.js
+++ b/server/drivers/mysql/index.js
@@ -34,6 +34,18 @@ function getSchemaSql(database) {
   `;
 }
 
+const BASE64_PREFIX = 'base64:';
+/**
+ * If the path starts with the base64 prefix it will create a buffer from the base64 string
+ * @param {string} path
+ */
+function loadData(path) {
+  if (path.startsWith(BASE64_PREFIX)) {
+    return Buffer.from(path.substring(BASE64_PREFIX.length), 'base64');
+  }
+  return fs.readFileSync(path);
+}
+
 class Client {
   constructor(connection) {
     this.connection = connection;
@@ -67,11 +79,11 @@ class Client {
     // TODO cache key/cert values
     if (connection.mysqlKey && connection.mysqlCert) {
       myConfig.ssl = {
-        key: fs.readFileSync(connection.mysqlKey),
-        cert: fs.readFileSync(connection.mysqlCert),
+        key: loadData(connection.mysqlKey),
+        cert: loadData(connection.mysqlCert),
       };
       if (connection.mysqlCA) {
-        myConfig.ssl['ca'] = fs.readFileSync(connection.mysqlCA);
+        myConfig.ssl['ca'] = loadData(connection.mysqlCA);
       }
     }
 

--- a/server/drivers/mysql2/index.js
+++ b/server/drivers/mysql2/index.js
@@ -33,6 +33,18 @@ function getSchemaSql(database) {
   `;
 }
 
+const BASE64_PREFIX = 'base64:';
+/**
+ * If the path starts with the base64 prefix it will create a buffer from the base64 string
+ * @param {string} path
+ */
+function loadData(path) {
+  if (path.startsWith(BASE64_PREFIX)) {
+    return Buffer.from(path.substring(BASE64_PREFIX.length), 'base64');
+  }
+  return fs.readFileSync(path);
+}
+
 class Client {
   constructor(connection) {
     this.connection = connection;
@@ -61,12 +73,12 @@ class Client {
       // TODO cache key/cert values
       if (connection.mysqlKey && connection.mysqlCert) {
         myConfig.ssl = {
-          key: fs.readFileSync(connection.mysqlKey),
-          cert: fs.readFileSync(connection.mysqlCert),
+          key: loadData(connection.mysqlKey),
+          cert: loadData(connection.mysqlCert),
         };
       }
       if (connection.mysqlCA) {
-        myConfig.ssl['ca'] = fs.readFileSync(connection.mysqlCA);
+        myConfig.ssl['ca'] = loadData(connection.mysqlCA);
       }
       if (connection.minTlsVersion) {
         myConfig.ssl['minVersion'] = connection.minTlsVersion;


### PR DESCRIPTION
It's a simple to allow adding CA, Cert and Key to the connection config of SQLPad in base64 form, this prevents the need of storing files locally, and enabling container deployments where persistent volumes are not an option to work with mysql instances where SSL is enforced.

To use it prefix the path field with `base64:` and add the base64 encoded content of the file in the path field to have it provide a base64 decoded buffer instead of buffer from `fs.readFileSync`.

