### PR TITLE
Use query timeout from config for postgres drivers

### DIFF
--- a/docs/connections.md
+++ b/docs/connections.md
@@ -146,6 +146,7 @@ A default connection selection can be set using environment variable `SQLPAD_DEF
 | `driver`                           | Must be `postgres`                                    |   text    |
 | `multiStatementTransactionEnabled` | Reuse db connection across query executions           |  boolean  |
 | `idleTimeoutSeconds`               | Seconds to allow connection to be idle before closing |  number   |
+| `queryTimeout`                     | Seconds to allow any query to run before cancelling   |  number   |
 | `host`                             | Host/Server/IP Address                                |   text    |
 | `port`                             | Port (optional)                                       |   text    |
 | `database`                         | Database                                              |   text    |

--- a/server/drivers/postgres/index.js
+++ b/server/drivers/postgres/index.js
@@ -31,6 +31,11 @@ class Client {
       stream: createSocksConnection(connection),
     };
 
+    const queryTimeout = parseInt(connection.queryTimeout, 10);
+    if (queryTimeout) {
+      pgConfig.query_timeout = queryTimeout * 1000;
+    }
+
     // TODO cache key/cert values
     if (connection.postgresKey && connection.postgresCert) {
       pgConfig.ssl = {
@@ -267,6 +272,11 @@ const fields = [
     label: 'Pre-query Statements (Optional)',
     placeholder:
       'Use to enforce session variables like:\n  SET statement_timeout = 15000;\n\nDeny multiple statements per query to avoid overwritten values.',
+  },
+  {
+    key: 'queryTimeout',
+    formType: 'TEXT',
+    label: 'Query Timeout (seconds)',
   },
 ];
 


### PR DESCRIPTION
Currently, there is no way to limit the query timeout, which can lead to very long running queries.
This can severly impact the database as autovacuums cannot delete newly produced rows while a transaction is running. (xmin)

I used the same code as the BigQuery driver.

the query_timeout param is documented here:
https://node-postgres.com/api/client