### PR TITLE
Default roles for Google Auth

### DIFF
--- a/config-example.env
+++ b/config-example.env
@@ -65,6 +65,9 @@ SQLPAD_GOOGLE_CLIENT_ID=""
 # Google Client Secret used for OAuth setup. Authorized redirect URI for sqlpad is '[baseurl]/auth/google/callback'
 SQLPAD_GOOGLE_CLIENT_SECRET=""
 
+# Default role for Google OAuth. May be either `admin` or `editor`
+SQLPAD_GOOGLE_DEFAULT_ROLE = "editor"
+
 # IP address to bind to. By default SQLPad will listen from all available addresses (0.0.0.0).
 SQLPAD_IP="0.0.0.0"
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -113,6 +113,9 @@ SQLPAD_GOOGLE_CLIENT_ID = ""
 # Google Client Secret used for OAuth setup. Authorized redirect URI for sqlpad is '[baseurl]/auth/google/callback'
 SQLPAD_GOOGLE_CLIENT_SECRET = ""
 
+# Default role for Google OAuth. May be either `admin` or `editor`
+SQLPAD_GOOGLE_DEFAULT_ROLE = "editor"
+
 # Public URL required
 PUBLIC_URL = "http://localhost"
 

--- a/server/auth-strategies/google.js
+++ b/server/auth-strategies/google.js
@@ -34,9 +34,23 @@ async function passportGoogleStrategyHandler(
     }
     const allowedDomains = config.get('allowedDomains');
     if (checkAllowedDomains(allowedDomains, email)) {
+      // Derive what the googleDefaultRole should be from config
+      // Value in config could be `editor` or `admin`
+      let googleDefaultRole = config
+        .get('googleDefaultRole')
+        .toLowerCase()
+        .trim();
+
+      // @TODO: Consider getting the role from the Google callback?
+      // @TODO: Unify the default role handlers across different auth strategies.
+      const validRoles = new Set(['editor', 'admin']);
+      if (!validRoles.has(googleDefaultRole)) {
+        googleDefaultRole = 'editor';
+      }
+
       const newUser = await models.users.create({
         email,
-        role: 'editor',
+        role: googleDefaultRole,
         signupAt: new Date(),
       });
       webhooks.userCreated(newUser);

--- a/server/lib/config/config-items.js
+++ b/server/lib/config/config-items.js
@@ -130,6 +130,11 @@ const configItems = [
     default: '',
   },
   {
+    key: 'googleDefaultRole',
+    envVar: 'SQLPAD_GOOGLE_DEFAULT_ROLE',
+    default: 'editor',
+  },
+  {
     key: 'publicUrl',
     envVar: 'PUBLIC_URL',
     default: '',


### PR DESCRIPTION
Use case: Reduce manual admin overhead through configurable default roles.

This brings Google OAuth behaviour closer to parity with that of [existing auth strategies like LDAP](https://github.com/sqlpad/sqlpad/blob/master/server/auth-strategies/ldap.js#L17).