### PR TITLE
Support base URL overrides

### DIFF
--- a/client/src/utilities/api.ts
+++ b/client/src/utilities/api.ts
@@ -302,7 +302,7 @@ export const api = {
           config: {
             ...fetched.config,
             baseUrl:
-              import.meta.env.VITE_UI_BASE_URL_OVERRIDE ||
+              import.meta.env.VITE_SPA_BASE_URL_OVERRIDE ||
               fetched.config.baseUrl,
           },
         };

--- a/client/src/utilities/api.ts
+++ b/client/src/utilities/api.ts
@@ -19,7 +19,8 @@ import {
   UserSelfUpdate,
 } from '../types';
 import { Links, parseLinkHeader } from '../utilities/parse-link-header';
-import baseUrl from './baseUrl';
+import { apiBaseUrl } from './baseUrl';
+import swrFetcher from './swr-fetcher';
 
 interface FetchResponse<DataT> {
   data?: DataT;
@@ -32,7 +33,7 @@ async function fetchJson<DataT = any>(
   url: any,
   body?: any
 ): Promise<FetchResponse<DataT>> {
-  const BASE_URL = baseUrl();
+  const BASE_URL = apiBaseUrl();
   const opts: RequestInit = {
     method: method.toUpperCase(),
     credentials: 'same-origin',
@@ -289,7 +290,24 @@ export const api = {
   },
 
   useAppInfo() {
-    return useSWR<AppInfo>('api/app', { dedupingInterval: 60000 });
+    import.meta.env.VITE_API_BASE_URL_OVERRIDE &&
+      apiBaseUrl(import.meta.env.VITE_API_BASE_URL_OVERRIDE);
+
+    return useSWR<AppInfo>('api/app', {
+      dedupingInterval: 60000,
+      fetcher: async (url: any) => {
+        const fetched = (await swrFetcher(url)) as AppInfo;
+        return {
+          ...fetched,
+          config: {
+            ...fetched.config,
+            baseUrl:
+              import.meta.env.VITE_UI_BASE_URL_OVERRIDE ||
+              fetched.config.baseUrl,
+          },
+        };
+      },
+    });
   },
 
   reloadAppInfo() {

--- a/client/src/utilities/baseUrl.ts
+++ b/client/src/utilities/baseUrl.ts
@@ -1,8 +1,23 @@
 let _baseUrl = '';
 
+/**
+ * Sets and/or gets the base URL of the frontend static content
+ */
 export default function baseUrl(value?: string) {
   if (typeof value === 'string') {
     _baseUrl = value;
   }
   return _baseUrl;
+}
+
+let _apiBaseUrl = '';
+
+/**
+ * Sets and/or gets the base URL of the backend API
+ */
+export function apiBaseUrl(value?: string) {
+  if (typeof value === 'string') {
+    _apiBaseUrl = value;
+  }
+  return _apiBaseUrl;
 }

--- a/client/src/utilities/baseUrl.ts
+++ b/client/src/utilities/baseUrl.ts
@@ -1,7 +1,7 @@
 let _baseUrl = '';
 
 /**
- * Sets and/or gets the base URL of the frontend static content
+ * Sets and/or gets the base URL of the frontend single-page app
  */
 export default function baseUrl(value?: string) {
   if (typeof value === 'string') {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -232,3 +232,18 @@ SQLPAD_HTTPS_CERT_PASSPHRASE = ""
 ## Authentication
 
 See [Authentication page](/authentication) for information on configuring authentication mechanisms.
+
+## React App Build Configuration
+
+The React build of the sqlpad client directory can be customized via .env files or build-time process environment variables.
+
+```bash
+# React App API/SPA Base URL Override
+# By default, the client-side sqlpad React app serves its Single-Page App (SPA, with routing handled in index.html) from the base URL path set by SQLPAD_BASE_URL.
+# If you're building the React app yourself and hosting the index.html at a different URL path from the API, you can set these environment variables at build time to specify the base URL paths of the index.html versus API.
+# This is helpful if you host the React single-page app in a Backend-for-frontend that handles authentication and relays requests to the sqlpad API.
+# Note that index.html will still expect to retrieve static content assets from the root URL.
+# For example, with the following settings, the React app will expect the API to be hosted behind the same domain, but under the /api/sqlpad path; the index.html will be served from /ui.  
+VITE_API_BASE_URL_OVERRIDE='/api/sqlpad'
+VITE_SPA_BASE_URL_OVERRIDE='/ui'
+```


### PR DESCRIPTION
For when UI and API are hosted at different URL paths, for example serving the built HTML/CSS/JS static content from a CDN, but serving the API from behind some API gateway.

I'd be happy to add docs if maintainer(s) like this feature.