### PR TITLE
Remove aws-sdk-mock dependency

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -112,7 +112,6 @@
     "odbc": "^2.2.2"
   },
   "devDependencies": {
-    "aws-sdk-mock": "^5.6.2",
     "bytes": "^3.1.2",
     "eslint": "^8.13.0",
     "eslint-config-airbnb-base": "^15.0.0",

--- a/server/test/api/test-connection.js
+++ b/server/test/api/test-connection.js
@@ -1,17 +1,10 @@
 const TestUtils = require('../utils');
-const AWSMock = require('aws-sdk-mock');
-const AWS = require('aws-sdk');
 
 describe('api/test-connection', function () {
   const utils = new TestUtils();
 
   before(function () {
     return utils.init(true);
-  });
-
-  after(function () {
-    // Prevent unadvertent mocking
-    AWSMock.restore();
   });
 
   it('tests connection success', async function () {
@@ -32,45 +25,6 @@ describe('api/test-connection', function () {
         filename: './test/fixtures/not-real-db',
       },
       500
-    );
-  });
-
-  it('tests connection success for async connections', async function () {
-    AWSMock.setSDKInstance(AWS);
-
-    AWSMock.mock('Athena', 'startQueryExecution', () => {
-      return Promise.resolve({
-        QueryExecutionId: '123e4567-e89b-12d3-a456-426614174000',
-      });
-    });
-    AWSMock.mock('Athena', 'getQueryResults', () => {
-      return Promise.resolve({ results: [] });
-    });
-    AWSMock.mock('Athena', 'getQueryExecution', () => {
-      return Promise.resolve({
-        QueryExecution: {
-          Status: { State: 'SUCCEEDED' },
-          ResultConfiguration: {
-            OutputLocation: 's3://test/location/data.csv',
-          },
-          StatementType: 'DML',
-        },
-      });
-    });
-    AWSMock.mock('S3', 'getObject', () => {
-      return Promise.resolve({});
-    });
-    await utils.post(
-      'admin',
-      '/api/test-connection',
-      {
-        name: 'test async connection',
-        driver: 'athena',
-        awsRegion: 'us-east-1',
-        awsAccessKeyId: 'access',
-        awsSecretAccessKey: 'secret',
-      },
-      200
     );
   });
 });

--- a/server/test/lib/connection-clients.js
+++ b/server/test/lib/connection-clients.js
@@ -3,8 +3,6 @@ const path = require('path');
 const TestUtils = require('../utils');
 const ConnectionClient = require('../../lib/connection-client');
 const { v4: uuidv4 } = require('uuid');
-const AWSMock = require('aws-sdk-mock');
-const AWS = require('aws-sdk');
 
 function wait(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -13,12 +11,9 @@ function wait(ms) {
 describe('lib/connection-clients', function () {
   const utils = new TestUtils();
   let connection1;
-  let connection2;
 
   before(async function () {
     await utils.init(true);
-
-    AWSMock.setSDKInstance(AWS);
 
     connection1 = await utils.post('admin', '/api/connections', {
       driver: 'sqlite',
@@ -32,18 +27,6 @@ describe('lib/connection-clients', function () {
       idleTimeoutSeconds: 1,
       multiStatementTransactionEnabled: true,
     });
-    connection2 = await utils.post('admin', '/api/connections', {
-      driver: 'athena',
-      name: 'async-connection-client-test',
-      data: {
-        awsRegion: 'us-east-1',
-      },
-    });
-  });
-
-  afterEach(async function () {
-    // Prevent unadvertently mocking
-    AWSMock.restore();
   });
 
   it('Keep-alive keeps it alive', async function () {
@@ -136,22 +119,6 @@ describe('lib/connection-clients', function () {
     );
   });
 
-  it('Succeeds starting an async query with a supported driver', async function () {
-    const connectionClient = new ConnectionClient(
-      connection2,
-      utils.users.admin
-    );
-    const uuid = uuidv4();
-
-    AWSMock.mock('Athena', 'startQueryExecution', () => {
-      return Promise.resolve({ QueryExecutionId: uuid });
-    });
-
-    const executionId = await connectionClient.startQueryExecution('SELECT 1');
-    assert(executionId);
-    assert.equal(executionId, uuid);
-  });
-
   it('Throws an error when cancelling an async query with unsupported driver', async function () {
     const connectionClient = new ConnectionClient(
       connection1,
@@ -162,19 +129,5 @@ describe('lib/connection-clients', function () {
       connectionClient.cancelQuery(uuidv4()),
       new Error('Driver SQLite does not support cancellation of queries')
     );
-  });
-
-  it('Succeeds cancelling an async query with a supported driver', async function () {
-    const connectionClient = new ConnectionClient(
-      connection2,
-      utils.users.admin
-    );
-
-    AWSMock.mock('Athena', 'stopQueryExecution', () => {
-      return Promise.resolve({});
-    });
-    const output = await connectionClient.cancelQuery(uuidv4());
-    assert(output);
-    assert.equal(output, true);
   });
 });

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -500,13 +500,6 @@
   resolved "https://registry.yarnpkg.com/@redis/time-series/-/time-series-1.0.4.tgz#af85eb080f6934580e4d3b58046026b6c2b18717"
   integrity sha512-ThUIgo2U/g7cCuZavucQTQzA9g9JbDDY2f64u3AbAoz/8vE2lt2U37LamDUVChhaDA3IRT9R6VvJwqnUfTJzng==
 
-"@sinonjs/commons@^1.7.0":
-  version "1.8.6"
-  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.6.tgz#80c516a4dc264c2a69115e7578d62581ff455ed9"
-  integrity sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==
-  dependencies:
-    type-detect "4.0.8"
-
 "@sinonjs/commons@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-2.0.0.tgz#fd4ca5b063554307e8327b4564bd56d3b73924a3"
@@ -520,29 +513,6 @@
   integrity sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==
   dependencies:
     "@sinonjs/commons" "^2.0.0"
-
-"@sinonjs/fake-timers@^7.0.4":
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz#2524eae70c4910edccf99b2f4e6efc5894aff7b5"
-  integrity sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==
-  dependencies:
-    "@sinonjs/commons" "^1.7.0"
-
-"@sinonjs/fake-timers@^9.1.2":
-  version "9.1.2"
-  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz#4eaab737fab77332ab132d396a3c0d364bd0ea8c"
-  integrity sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==
-  dependencies:
-    "@sinonjs/commons" "^1.7.0"
-
-"@sinonjs/samsam@^7.0.1":
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-7.0.1.tgz#5b5fa31c554636f78308439d220986b9523fc51f"
-  integrity sha512-zsAk2Jkiq89mhZovB2LLOdTCxJF4hqqTToGP0ASWlhp4I1hqOjcfmZGafXntCN7MDC6yySH0mFHrYtHceOeLmw==
-  dependencies:
-    "@sinonjs/commons" "^2.0.0"
-    lodash.get "^4.4.2"
-    type-detect "^4.0.8"
 
 "@sinonjs/text-encoding@^0.7.1":
   version "0.7.2"
@@ -1024,15 +994,6 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-aws-sdk-mock@^5.6.2:
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk-mock/-/aws-sdk-mock-5.8.0.tgz#2556a79010a883f4bd5a566ce63bc244cee67579"
-  integrity sha512-s0Vy4DObFmVJ6h1uTw1LGInOop77oF0JXH2N39Lv+1Wss274EowVk9odhM4Sji4mynXcM5oSu68uYqkJRviDRA==
-  dependencies:
-    aws-sdk "^2.1231.0"
-    sinon "^14.0.1"
-    traverse "^0.6.6"
-
 aws-sdk@^2.1113.0:
   version "2.1383.0"
   resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1383.0.tgz#ae74e0acddec874b637263ec174841306460d696"
@@ -1048,22 +1009,6 @@ aws-sdk@^2.1113.0:
     util "^0.12.4"
     uuid "8.0.0"
     xml2js "0.5.0"
-
-aws-sdk@^2.1231.0:
-  version "2.1255.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1255.0.tgz#f5af4d7cbc78c7c04d0c65cf882c89790f563da7"
-  integrity sha512-S3oPXrBVOWquVL1bzH79bz88PgF4GqLcUbIph5yJ+pWW0OKNWGWKW1PDwtWi6ma+8mKXJ1gGKgy6R2hD57AsLw==
-  dependencies:
-    buffer "4.9.2"
-    events "1.1.1"
-    ieee754 "1.1.13"
-    jmespath "0.16.0"
-    querystring "0.2.0"
-    sax "1.2.1"
-    url "0.10.3"
-    util "^0.12.4"
-    uuid "8.0.0"
-    xml2js "0.4.19"
 
 aws-sdk@^2.878.0:
   version "2.1362.0"
@@ -1730,11 +1675,6 @@ diff@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
   integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
-
-diff@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-5.1.0.tgz#bc52d298c5ea8df9194800224445ed43ffc87e40"
-  integrity sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==
 
 digest-header@^1.0.0:
   version "1.0.0"
@@ -3348,11 +3288,6 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash.get@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
-  integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
-
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
@@ -3816,17 +3751,6 @@ nise@^5.1.1:
   dependencies:
     "@sinonjs/commons" "^2.0.0"
     "@sinonjs/fake-timers" "^10.0.2"
-    "@sinonjs/text-encoding" "^0.7.1"
-    just-extend "^4.0.2"
-    path-to-regexp "^1.7.0"
-
-nise@^5.1.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/nise/-/nise-5.1.2.tgz#a7b8909c216b3491fd4fc0b124efb69f3939b449"
-  integrity sha512-+gQjFi8v+tkfCuSCxfURHLhRhniE/+IaYbIphxAN2JRR9SHKhY8hgXpaXiYfHdw+gcGe4buxgbprBQFab9FkhA==
-  dependencies:
-    "@sinonjs/commons" "^2.0.0"
-    "@sinonjs/fake-timers" "^7.0.4"
     "@sinonjs/text-encoding" "^0.7.1"
     just-extend "^4.0.2"
     path-to-regexp "^1.7.0"
@@ -5103,18 +5027,6 @@ simple-swizzle@^0.2.2:
   dependencies:
     is-arrayish "^0.3.1"
 
-sinon@^14.0.1:
-  version "14.0.2"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-14.0.2.tgz#585a81a3c7b22cf950762ac4e7c28eb8b151c46f"
-  integrity sha512-PDpV0ZI3ZCS3pEqx0vpNp6kzPhHrLx72wA0G+ZLaaJjLIYeE0n8INlgaohKuGy7hP0as5tbUd23QWu5U233t+w==
-  dependencies:
-    "@sinonjs/commons" "^2.0.0"
-    "@sinonjs/fake-timers" "^9.1.2"
-    "@sinonjs/samsam" "^7.0.1"
-    diff "^5.0.0"
-    nise "^5.1.2"
-    supports-color "^7.2.0"
-
 smart-buffer@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
@@ -5437,7 +5349,7 @@ supports-color@8.1.1:
   dependencies:
     has-flag "^4.0.0"
 
-supports-color@^7.1.0, supports-color@^7.2.0:
+supports-color@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
@@ -5635,7 +5547,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-detect@4.0.8, type-detect@^4.0.8:
+type-detect@4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
@@ -6039,14 +5951,6 @@ xml-encryption@^3.0.2:
     escape-html "^1.0.3"
     xpath "0.0.32"
 
-xml2js@0.4.19:
-  version "0.4.19"
-  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
-  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
-  dependencies:
-    sax ">=0.6.0"
-    xmlbuilder "~9.0.1"
-
 xml2js@0.5.0, xml2js@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.5.0.tgz#d9440631fbb2ed800203fad106f2724f62c493b7"
@@ -6064,11 +5968,6 @@ xmlbuilder@~11.0.0:
   version "11.0.1"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
   integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
-
-xmlbuilder@~9.0.1:
-  version "9.0.7"
-  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
-  integrity sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ==
 
 xpath@0.0.27:
   version "0.0.27"


### PR DESCRIPTION
`aws-sdk-mock` has had an npm audit advisory via a transitive dependency, and has yet to be updated. Given this dependency is used for testing only, and no feature work is being performed in the future, this dependency can be removed to reduce maintenance burden.