### PR TITLE
[Bug Fix] Modify docker-entrypoint Script to allow scripts which can set environment variables

### DIFF
--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -8,4 +8,5 @@ if [ -d "/etc/docker-entrypoint.d" ]; then
         . "$file"
     done < <(find /etc/docker-entrypoint.d -maxdepth 1 -name '*.sh' -type f  -print0)
 fi
+set +a
 exec node /usr/app/server.js $@

--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -1,11 +1,11 @@
 #!/bin/bash
 set -e
+set -a
 # This iterates any sh file in the directory and executes them before our server starts
 # Note: we intentionally source the files, allowing scripts to set vars that override default behavior.
 if [ -d "/etc/docker-entrypoint.d" ]; then
-    find /etc/docker-entrypoint.d -name '*.sh' -print0 | 
-    while IFS= read -r -d '' line; do 
-        . "$line"
-    done
+    while IFS= read -r -d $'\0' file; do
+        . "$file"
+    done < <(find /etc/docker-entrypoint.d -maxdepth 1 -name '*.sh' -type f  -print0)
 fi
 exec node /usr/app/server.js $@

--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -e
-set -a
 # This iterates any sh file in the directory and executes them before our server starts
 # Note: we intentionally source the files, allowing scripts to set vars that override default behavior.
 if [ -d "/etc/docker-entrypoint.d" ]; then
@@ -8,5 +7,4 @@ if [ -d "/etc/docker-entrypoint.d" ]; then
         . "$file"
     done < <(find /etc/docker-entrypoint.d -maxdepth 1 -name '*.sh' -type f  -print0)
 fi
-set +a
 exec node /usr/app/server.js $@


### PR DESCRIPTION
<h2>
Why?
</h2>
The current implementation of docker-entrypoint spawns a different sub-shell because of the pipeline `|`used at line 6 in https://github.com/sqlpad/sqlpad/blob/master/docker-entrypoint

Due to this, scripts used to set environment variables are failing as those variables are only set in a child shell and cannot be passed on to the parent shell. Hence, it is not able to run what it is claiming in the comment:
`# Note: we intentionally source the files, allowing scripts to set vars that override default behavior.`

<h2>
What?
</h2>

This change allows the scripts to run in the current scope of the script (process) and allows the output of find to be used in setting variables.
Instead of pipelining the outpput of files to the while loop, it feeds it to the while loop in the same context. 
I have also added the `set -a` line at the start to set the values we source after the current line as environment variables. The `-a` flag marks variables and functions which are modified or created for export to the environment of subsequent commands. The `set +a` line at the end is unsetting this flag so commands run subsequently do not get exported automatically.

<h2>
References
</h2>

[GNU Bash Manual: Pipelines](https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#Pipelines)
[GNU Bash Manual: Set -a](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html)
[Stack Overflow discussion on similar issue](https://stackoverflow.com/questions/20796200/how-to-loop-over-files-in-directory-and-change-path-and-add-suffix-to-filename)

<h2>
Testing
</h2>

I have tested locally by using the following files:
<details><summary>docker-entrypoint.d/abc.sh</summary><code>
export abc="File1"
</code></details>

<details><summary>docker-entrypoint.d/pqr.sh</summary><code>
export pqr="File2"
</code></details>

<details><summary>docker-entrypoint.sh</summary><code>
set -e
set -a
# This iterates any sh file in the directory and executes them before our server starts
# Note: we intentionally source the files, allowing scripts to set vars that override default behavior.
if [ -d "./docker-entrypoint.d" ]; then
    while IFS= read -r -d $'\0' file; do
        . "$file"
    done < <(find ./docker-entrypoint.d -maxdepth 1 -name '*.sh' -type f  -print0)
fi
echo "ABC="$abc
echo "PQR="$pqr
</code></details>

On running docker-entrypoint.sh, I was able to see the updated values of the environment variables `$abc` and `$pqr`