### PR TITLE
Re-add support for arm64 container builds.

### DIFF
--- a/.github/workflows/docker-ci-tags.yml
+++ b/.github/workflows/docker-ci-tags.yml
@@ -46,6 +46,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Fixes #1173. This was (presumably accidentally) removed in https://github.com/sqlpad/sqlpad/pull/1170